### PR TITLE
feat: new updateSubAccountDrips function

### DIFF
--- a/src/dripsclient.ts
+++ b/src/dripsclient.ts
@@ -83,6 +83,19 @@ export class DripsClient {
       )
     }
 
+  updateSubAccountDrips: DaiDripsHub['setDrips(uint256,uint64,uint128,(address,uint128)[],int128,(address,uint128)[])'] =
+    (subAccountId, lastUpdate, lastBalance, currentReceivers, balanceDelta, newReceivers) => {
+      if (!this.signer) throw "Not connected to wallet"
+
+      validateDrips(newReceivers)
+
+      const contractSigner = this.hubContract.connect(this.signer)
+
+      return contractSigner['setDrips(uint256,uint64,uint128,(address,uint128)[],int128,(address,uint128)[])'](
+        subAccountId, lastUpdate, lastBalance, currentReceivers, balanceDelta, newReceivers
+      )
+    }
+
   updateUserSplits: DaiDripsHub['setSplits'] =
     (currentReceivers, newReceivers) => {
       if (!this.signer) throw "Not connected to wallet"


### PR DESCRIPTION
Adds a new `updateSubAccountDrips` function, which works similarly to `updateUserDrips`, except either updating an existing or creating a new sub-account for the user.

Resolves #16