### PR TITLE
Add support for gives

### DIFF
--- a/src/dripsclient.ts
+++ b/src/dripsclient.ts
@@ -1,4 +1,4 @@
-import type { providers, Signer } from "ethers";
+import { BigNumberish, providers, Signer, utils } from "ethers";
 import type { Dai, DaiDripsHub, RadicleRegistry } from '../contracts';
 import { getContractsForNetwork } from './contracts'
 import { constants } from 'ethers';
@@ -100,6 +100,24 @@ export class DripsClient {
 
       return contractSigner['setSplits'](currentReceivers, newReceivers)
     }
+
+	giveFromUser(receiver: string, amount: BigNumberish) {
+		if (!this.signer) throw new Error("Not connected to wallet")
+		if (!utils.isAddress(receiver)) throw new Error(`Invalid recipient: "${receiver}" is not an Ethereum address`)
+
+		const contractSigner = this.hubContract.connect(this.signer)
+
+		return contractSigner["give(address,uint128)"](receiver, amount)
+	}
+
+	giveFromAccount(account: BigNumberish, receiver: string, amount: BigNumberish) {
+		if (!this.signer) throw new Error("Not connected to wallet")
+		if (!utils.isAddress(receiver)) throw new Error(`Invalid recipient: "${receiver}" is not an Ethereum address`)
+
+		const contractSigner = this.hubContract.connect(this.signer)
+
+		return contractSigner["give(uint256,address,uint128)"](account, receiver, amount)
+	}
 
   // check how much DAI the DripsHub is allowed to spend on behalf of the signed-in user
   getAllowance() {

--- a/tests/dripsclient.tests.ts
+++ b/tests/dripsclient.tests.ts
@@ -586,6 +586,180 @@ describe('DripsClient', () => {
     });
   });
 
+  describe('giveFromUser()', async () => {
+    it('should throw if signer property is falsy', async () => {
+      // Arrange.
+      dripsClient.signer = undefined;
+
+      const payload = {
+        receiver: ethers.Wallet.createRandom().address,
+        amount: 10,
+      };
+
+      let threw = false;
+
+      try {
+        // Act.
+        await dripsClient.giveFromUser(payload.receiver, payload.amount);
+      } catch (error) {
+        // Assert.
+        assert.typeOf(error, 'Error');
+        assert.equal('Not connected to wallet', error.message);
+        threw = true;
+      }
+      // Assert.
+      assert.isTrue(threw, "Expected to throw but it didn't");
+    });
+
+    it('should throw if receiver is not a valid Etherium address', async () => {
+      // Arrange.
+      await dripsClient.connect();
+
+      const payload = {
+        receiver: 'invalid Etherium address',
+        amount: 10,
+      };
+
+      let threw = false;
+
+      try {
+        // Act.
+        await dripsClient.giveFromUser(payload.receiver, payload.amount);
+      } catch (error) {
+        // Assert.
+        assert.typeOf(error, 'Error');
+        assert.equal(
+          `Invalid recipient: "${payload.receiver}" is not an Ethereum address`,
+          error.message
+        );
+        threw = true;
+      }
+      // Assert.
+      assert.isTrue(threw, "Expected to throw but it didn't");
+    });
+
+    it('should delegate the call to the give() contract method', async () => {
+      // Arrange.
+      await dripsClient.connect();
+
+      const payload = {
+        receiver: ethers.Wallet.createRandom().address,
+        amount: 10,
+      };
+
+      hubContractStub['give(address,uint128)']
+        .withArgs(payload.receiver, payload.amount)
+        .resolves({} as ContractTransaction);
+
+      // Act.
+      await dripsClient.giveFromUser(payload.receiver, payload.amount);
+
+      // Assert.
+      assert(
+        hubContractStub['give(address,uint128)'].calledOnceWithExactly(
+          payload.receiver,
+          payload.amount
+        ),
+        'Expected giveFromUser() method to be called with different arguments'
+      );
+    });
+  });
+
+  describe('giveFromAccount()', async () => {
+    it('should throw if signer property is falsy', async () => {
+      // Arrange.
+      dripsClient.signer = undefined;
+
+      const payload = {
+        account: 1,
+        receiver: ethers.Wallet.createRandom().address,
+        amount: 10,
+      };
+
+      let threw = false;
+
+      try {
+        // Act.
+        await dripsClient.giveFromAccount(
+          payload.account,
+          payload.receiver,
+          payload.amount
+        );
+      } catch (error) {
+        // Assert.
+        assert.typeOf(error, 'Error');
+        assert.equal('Not connected to wallet', error.message);
+        threw = true;
+      }
+      // Assert.
+      assert.isTrue(threw, "Expected to throw but it didn't");
+    });
+
+    it('should throw if receiver is not a valid Etherium address', async () => {
+      // Arrange.
+      await dripsClient.connect();
+
+      const payload = {
+        account: 1,
+        receiver: 'invalid Etherium address',
+        amount: 10,
+      };
+
+      let threw = false;
+
+      try {
+        // Act.
+        await dripsClient.giveFromAccount(
+          payload.account,
+          payload.receiver,
+          payload.amount
+        );
+      } catch (error) {
+        // Assert.
+        assert.typeOf(error, 'Error');
+        assert.equal(
+          `Invalid recipient: "${payload.receiver}" is not an Ethereum address`,
+          error.message
+        );
+        threw = true;
+      }
+      // Assert.
+      assert.isTrue(threw, "Expected to throw but it didn't");
+    });
+
+    it('should delegate the call to the give() contract method', async () => {
+      // Arrange.
+      await dripsClient.connect();
+
+      const payload = {
+        account: 1,
+        receiver: ethers.Wallet.createRandom().address,
+        amount: 10,
+      };
+
+      hubContractStub['give(address,uint128)']
+        .withArgs(payload.receiver, payload.amount)
+        .resolves({} as ContractTransaction);
+
+      // Act.
+      await dripsClient.giveFromAccount(
+        payload.account,
+        payload.receiver,
+        payload.amount
+      );
+
+      // Assert.
+      assert(
+        hubContractStub['give(uint256,address,uint128)'].calledOnceWithExactly(
+          payload.account,
+          payload.receiver,
+          payload.amount
+        ),
+        'Expected giveFromAccount() method to be called with different arguments'
+      );
+    });
+  });
+
   describe('getAllowance()', () => {
     it('should throw when address property is falsy', async () => {
       // Arrange.


### PR DESCRIPTION
Summary:

- Add `giveFromUser` method.
- Add `giveFromAccount` method.
- Add unit tests.
- Resolves: https://github.com/radicle-dev/drips-js-sdk/issues/15

I followed the approach of having two separate methods instead of one with an optional parameter, to keep it consistent with the other methods. We could of course change it to one if we want.

**Note**: I branched out of the unit test _feature_ branch so that I can also add the relevant unit tests  - watch out when merging for conflicts/sync with the right branch. etc. 🤓

Also, a small comment, from our discussion [here](https://discord.com/channels/841318878125490186/930862758017245215/983683554548531210), in the future, we might not need to support the give-from-account functionality.