### PR TITLE
MVP squeezing implementation (to be closed - obsolete)

### DIFF
--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -2,10 +2,11 @@
 
 import type { Network } from '@ethersproject/networks';
 import type { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
-import type { BigNumberish, ContractTransaction, BigNumber } from 'ethers';
-import { constants } from 'ethers';
-import type { DripsReceiverStruct, SplitsReceiverStruct } from 'contracts/AddressDriver';
+import type { BigNumberish, ContractTransaction, BigNumber, BytesLike } from 'ethers';
+import { ethers, constants } from 'ethers';
+import type { DripsHistoryStruct, DripsReceiverStruct, SplitsReceiverStruct } from 'contracts/AddressDriver';
 import type { DripsMetadata } from 'src/common/types';
+import type { DripsSetEvent } from 'src/DripsSubgraph/types';
 import DripsSubgraphClient from '../DripsSubgraph/DripsSubgraphClient';
 import DripsHubClient from '../DripsHub/DripsHubClient';
 import Utils from '../utils';
@@ -305,6 +306,150 @@ export default class AddressDriverClient {
 			this.#formatDripsReceivers(newReceivers),
 			transferToAddress
 		);
+	}
+
+	/**
+	 * Receives drips from the currently running cycle from a single sender based on the given history.
+	 * It doesn't receive drips from the previous, finished cycles.
+	 * @param  {string} tokenAddress The ERC20 token address.
+	 * @param  {BigNumberish} senderId The ID of the user sending drips to squeeze funds from.
+	 * @param  {BigNumberish} historyHash The `sender`'s history hash which was valid right before they set up the sequence of configurations described by `dripsHistory`.
+	 * @param  {BigNumberish} dripsHistory The sequence of the sender's drips configurations.
+	 * It can start at an arbitrary past configuration, but must describe all the configurations
+	 * which have been used since then including the current one, in the chronological order.
+	 * Only drips described by `dripsHistory` will be squeezed.
+	 * If `dripsHistory` entries have no receivers, they won't be squeezed.
+	 * The next call to `squeezeDrips` will be able to squeeze only funds which
+	 * have been dripped after the last timestamp squeezed in this call.
+	 * This may cause some funds to be unreceivable until the current cycle ends.
+	 * @returns A `Promise` which resolves to the contract transaction.
+	 * @throws {DripsErrors.addressError} if the `tokenAddress` address is not valid.
+	 * @throws {DripsErrors.argumentMissingError} if any of the required parameters is missing.
+	 */
+	public async squeezeDripsFromHistory(
+		tokenAddress: string,
+		senderId: BigNumberish,
+		historyHash: BytesLike,
+		dripsHistory: DripsHistoryStruct[]
+	): Promise<ContractTransaction> {
+		validateAddress(tokenAddress);
+
+		if (isNullOrUndefined(senderId)) {
+			throw DripsErrors.argumentMissingError(
+				`Could not squeeze drips: '${nameOf({ senderId })}' is missing.`,
+				nameOf({ senderId })
+			);
+		}
+
+		if (!historyHash) {
+			throw DripsErrors.argumentMissingError(
+				`Could not squeeze drips: '${nameOf({ historyHash })}' is missing.`,
+				nameOf({ historyHash })
+			);
+		}
+
+		if (!dripsHistory) {
+			throw DripsErrors.argumentMissingError(
+				`Could not squeeze drips: '${nameOf({ dripsHistory })}' is missing.`,
+				nameOf({ dripsHistory })
+			);
+		}
+
+		return this.#addressDriverContract.squeezeDrips(tokenAddress, senderId, historyHash, dripsHistory);
+	}
+
+	/**
+	 * Receives all drips from the currently running cycle from a single sender.
+	 * It doesn't receive drips from the previous, finished cycles.
+	 * @param  {string} tokenAddress The ERC20 token address.
+	 * @param  {BigNumberish} senderId The ID of the user sending drips to squeeze funds from.
+	 * @returns A `Promise` which resolves to the contract transaction.
+	 * @throws {DripsErrors.addressError} if the `tokenAddress` address is not valid.
+	 * @throws {DripsErrors.argumentMissingError} if the `senderId` is missing.
+	 */
+	public async squeezeDrips(tokenAddress: string, senderId: BigNumberish): Promise<ContractTransaction> {
+		validateAddress(tokenAddress);
+
+		if (isNullOrUndefined(senderId)) {
+			throw DripsErrors.argumentMissingError(
+				`Could not squeeze drips: '${nameOf({ senderId })}' is missing.`,
+				nameOf({ senderId })
+			);
+		}
+
+		// Get all `DripsSet` events (drips configurations) for the sender.
+		const dripsSetEvents = (await this.#subgraph.getDripsSetEventsByUserId(senderId.toString()))
+			// Sort by `blockTimestamp` DESC - the first ones will be the most recent ones.
+			?.sort((a, b) => Number(b.blockTimestamp) - Number(a.blockTimestamp));
+
+		const dripsToSqueeze: DripsSetEvent[] = [];
+		const { currentCycleStartDate } = Utils.Cycle.getInfo(this.network.chainId);
+		const userId = await this.getUserId(); // Squeeze funds for the "connected user".
+
+		// Iterate over all events.
+		if (dripsSetEvents?.length) {
+			for (let i = 0; i < dripsSetEvents.length; i++) {
+				const dripsConfiguration = dripsSetEvents[i];
+
+				// Keep the drips configurations of the current cycle.
+				const eventTimestamp = new Date(Number(dripsConfiguration.blockTimestamp));
+				if (eventTimestamp >= currentCycleStartDate) {
+					dripsToSqueeze.push(dripsConfiguration);
+				}
+				// Get the first event before the current cycle.
+				else {
+					dripsToSqueeze.push(dripsConfiguration);
+					break;
+				}
+			}
+		}
+
+		// The last (oldest) event provides the hash prior to the DripsHistory (or 0, if there was only one event).
+		const historyHash =
+			dripsToSqueeze?.length > 1
+				? dripsToSqueeze[dripsToSqueeze.length - 1].dripsHistoryHash
+				: ethers.constants.HashZero;
+
+		// Transform the events into `DripsHistory` objects.
+		const dripsHistory: DripsHistoryStruct[] = dripsToSqueeze
+			?.map((dripsSetEvent) => {
+				// By default a configuration should not be squeezed.
+				let shouldSqueeze = false;
+
+				// Check the configurations for the given asset that have receivers, the others should not be squeezed.
+				if (
+					dripsSetEvent.assetId === Utils.Asset.getIdFromAddress(tokenAddress) &&
+					dripsSetEvent.dripsReceiverSeenEvents?.length
+				) {
+					// Iterate over all event's `DripsReceiverSeen` events (receivers).
+					for (let i = 0; i < dripsSetEvent.dripsReceiverSeenEvents.length; i++) {
+						const receiver = dripsSetEvent.dripsReceiverSeenEvents[i];
+
+						// Mark as squeezable only the events that drip to the "connected user".
+						if (receiver.receiverUserId === userId) {
+							shouldSqueeze = true;
+							break; // Break, because drips receivers are unique.
+						}
+					}
+				}
+
+				const historyItem: DripsHistoryStruct = {
+					dripsHash: shouldSqueeze ? ethers.constants.HashZero : dripsSetEvent.receiversHash, // If it's non-zero, `receivers` must be empty.
+					receivers: shouldSqueeze // If it's non-empty, `dripsHash` must be 0.
+						? dripsSetEvent.dripsReceiverSeenEvents.map((r) => ({
+								userId: r.receiverUserId,
+								config: r.config
+						  }))
+						: [],
+					updateTime: dripsSetEvent.blockTimestamp,
+					maxEnd: dripsSetEvent.maxEnd
+				};
+
+				return historyItem;
+			})
+			.reverse();
+
+		return this.#addressDriverContract.squeezeDrips(tokenAddress, senderId, historyHash, dripsHistory);
 	}
 
 	// #region Private Methods

--- a/src/DripsSubgraph/DripsSubgraphClient.ts
+++ b/src/DripsSubgraph/DripsSubgraphClient.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-await-in-loop */
 import Utils from '../utils';
-import { nameOf } from '../common/internals';
+import { nameOf, toBN } from '../common/internals';
 import { DripsErrors } from '../common/DripsError';
 import * as gql from './gql';
-import type { DripsSetEvent, SplitEntry, UserAssetConfig } from './types';
+import type { DripsReceiverSeenEvent, DripsSetEvent, SplitEntry, UserAssetConfig } from './types';
 
 /**
  * A client for querying the Drips Subgraph.
@@ -123,6 +123,92 @@ export default class DripsSubgraphClient {
 		const response = await this.query<ApiResponse>(gql.getDripsSetEventsByUserId, { userId });
 
 		return response?.data?.dripsSetEvents || [];
+	}
+
+	/**
+	 * Returns the senders for which drips can be squeezed for a given receiver.
+	 * @param  {string} receiverId The receiver's user ID.
+	 * @returns A `Promise` which resolves to a map with keys being the sender IDs and values the asset IDs.
+	 * @throws {DripsErrors.subgraphQueryError} if the query fails.
+	 */
+	public async getSqueezableSenders(receiverId: string): Promise<Record<string, string[]>> {
+		type ApiResponse = {
+			dripsReceiverSeenEvents: DripsReceiverSeenEvent[];
+		};
+
+		// Get all `DripsReceiverSeen` events for the given receiver.
+		const response = await this.query<ApiResponse>(gql.getDripsReceiverSeenEventsByReceiverId, { receiverId });
+		const dripsReceiverSeenEvents = response?.data?.dripsReceiverSeenEvents;
+
+		if (!dripsReceiverSeenEvents?.length) {
+			return {};
+		}
+
+		const { currentCycleStartDate } = Utils.Cycle.getInfo(this.#chainId);
+		const squeezableSenders: Record<string, string[]> = {}; // key: senderId, value: [assetId, assetId]
+		const processedSenders: Record<string, boolean> = {};
+
+		// Iterate over all `DripsReceiverSeen` events.
+		for (let i = 0; i < dripsReceiverSeenEvents.length; i++) {
+			const dripsReceiverSeenEvent = dripsReceiverSeenEvents[i];
+
+			const { senderUserId } = dripsReceiverSeenEvent;
+
+			if (!processedSenders[senderUserId]) {
+				// Mark the sender as processed in order not to process the same sender ID multiple times.
+				processedSenders[senderUserId] = true;
+
+				// For each event's sender, get all user asset configurations.
+				const senderAssetConfigs = await this.getAllUserAssetConfigsByUserId(senderUserId);
+
+				// Iterate over all sender configurations.
+				for (let j = 0; j < senderAssetConfigs.length; j++) {
+					const senderAssetConfig = senderAssetConfigs[j];
+
+					// Iterate over all configuration drip entries.
+					for (let k = 0; k < senderAssetConfig.dripsEntries.length; k++) {
+						const dripEntry = senderAssetConfig.dripsEntries[k];
+
+						// Get the rate of dripping from the config.
+						const { amountPerSec } = Utils.DripsReceiverConfiguration.fromUint256(
+							senderAssetConfig.dripsEntries[0]?.config
+						);
+
+						// Keep only the configurations that drip to the `receiverId`.
+						if (dripEntry.userId === receiverId && amountPerSec > 0 && senderAssetConfig.balance > 0) {
+							const configUpdateTimestamp = new Date(toBN(senderAssetConfig.lastUpdatedBlockTimestamp).toNumber());
+
+							// If the configuration was updated before the start of the current timestamp.
+							if (configUpdateTimestamp < currentCycleStartDate) {
+								// Calculate the seconds that elapsed from the time the configuration was updated until the start of the current cycle.
+								const elapsedSecsUntilCurrentCycleStart = Math.floor(
+									(currentCycleStartDate.getTime() - configUpdateTimestamp.getTime()) / 1000
+								);
+
+								const drippedAmount = toBN(amountPerSec).mul(elapsedSecsUntilCurrentCycleStart);
+
+								// If the balance is greater than the dripped amount, the receiver will have drips to squeeze in the current cycle.
+								if (senderAssetConfig.balance > drippedAmount) {
+									if (!squeezableSenders[senderUserId]) {
+										squeezableSenders[senderUserId] = [];
+									}
+									squeezableSenders[senderUserId].push(senderAssetConfig.assetId);
+								}
+							}
+							// If the configuration was updated after the start of the current timestamp the receiver will have drips to squeeze in the current cycle.
+							else {
+								if (!squeezableSenders[senderUserId]) {
+									squeezableSenders[senderUserId] = [];
+								}
+								squeezableSenders[senderUserId].push(senderAssetConfig.assetId);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return squeezableSenders;
 	}
 
 	/** @internal */

--- a/tests/DripsSubgraph/DripsSubgraphClient.tests.ts
+++ b/tests/DripsSubgraph/DripsSubgraphClient.tests.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { DripsErrorCode } from '../../src/common/DripsError';
 import DripsSubgraphClient from '../../src/DripsSubgraph/DripsSubgraphClient';
 import * as gql from '../../src/DripsSubgraph/gql';
-import type { UserAssetConfig, SplitEntry } from '../../src/DripsSubgraph/types';
+import type { UserAssetConfig, SplitEntry, DripsReceiverSeenEvent } from '../../src/DripsSubgraph/types';
 import Utils from '../../src/utils';
 import type { DripsSetEventObject } from '../../contracts/DripsHub';
 import { toBN } from '../../src/common/internals';
@@ -280,6 +280,254 @@ describe('DripsSubgraphClient', () => {
 			assert.isEmpty(dripsSetEvents);
 			assert(
 				clientStub.calledOnceWithExactly(gql.getDripsSetEventsByUserId, { userId }),
+				'Expected method to be called with different arguments'
+			);
+		});
+	});
+
+	describe('getSqueezableSenders()', () => {
+		it('should return an empty list when there are no DripsReceiverSeen events for the specified receiver', async () => {
+			// Arrange
+			sinon.stub(testSubgraphClient, 'query').resolves({
+				data: {}
+			});
+
+			// Act
+			const squeezableSenders = await testSubgraphClient.getSqueezableSenders('1');
+
+			// Assert
+			assert.isEmpty(squeezableSenders);
+		});
+
+		it('should return the expected result', async () => {
+			// Arrange
+			const receiverId = '1';
+			const { currentCycleStartDate } = Utils.Cycle.getInfo(5);
+			const beforeCurrentCycleStart = currentCycleStartDate.setUTCDate(currentCycleStartDate.getUTCDate() - 1);
+			const afterCurrentCycleStart = currentCycleStartDate.setUTCDate(currentCycleStartDate.getUTCDate() + 2);
+			const dripsReceiverSeenEvents: DripsReceiverSeenEvent[] = [
+				{
+					senderUserId: '1'
+				},
+				{
+					senderUserId: '1'
+				},
+				{
+					senderUserId: '2'
+				},
+				{
+					senderUserId: '2'
+				},
+				{
+					senderUserId: '3'
+				},
+				{
+					senderUserId: '4'
+				},
+				{
+					senderUserId: '5'
+				},
+				{
+					senderUserId: '6'
+				}
+			];
+			const sender1AssetConfigs: UserAssetConfig[] = [
+				{
+					assetId: '1',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: beforeCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig,
+				{
+					assetId: '1',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: afterCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: '999'
+						}
+					]
+				} as UserAssetConfig,
+				{
+					assetId: '2',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: beforeCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig
+			];
+			const sender2AssetConfigs: UserAssetConfig[] = [
+				{
+					assetId: '1',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: beforeCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig,
+				{
+					assetId: '2',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: afterCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig
+			];
+			const sender3AssetConfigs: UserAssetConfig[] = [
+				{
+					assetId: '1',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: afterCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig,
+				{
+					assetId: '2',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: afterCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig
+			];
+			const sender4AssetConfigs: UserAssetConfig[] = [
+				{
+					assetId: '1',
+					balance: 1,
+					lastUpdatedBlockTimestamp: beforeCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig
+			];
+			const sender5AssetConfigs: UserAssetConfig[] = [
+				{
+					assetId: '1',
+					balance: 0,
+					lastUpdatedBlockTimestamp: afterCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: receiverId
+						}
+					]
+				} as UserAssetConfig
+			];
+			const sender6AssetConfigs: UserAssetConfig[] = [
+				{
+					assetId: '1',
+					balance: 1_000_000,
+					lastUpdatedBlockTimestamp: afterCurrentCycleStart,
+					dripsEntries: [
+						{
+							config: Utils.DripsReceiverConfiguration.toUint256String({
+								amountPerSec: 1,
+								duration: 0,
+								start: 0
+							}),
+							userId: '100'
+						}
+					]
+				} as UserAssetConfig
+			];
+
+			const getAllUserAssetConfigsByUserIdStub = sinon
+				.stub(testSubgraphClient, 'getAllUserAssetConfigsByUserId')
+				.onCall(0)
+				.resolves(sender1AssetConfigs)
+				.onCall(1)
+				.resolves(sender2AssetConfigs)
+				.onCall(2)
+				.resolves(sender3AssetConfigs)
+				.onCall(3)
+				.resolves(sender4AssetConfigs)
+				.onCall(4)
+				.resolves(sender5AssetConfigs)
+				.onCall(5)
+				.resolves(sender6AssetConfigs);
+
+			const queryStub = sinon
+				.stub(testSubgraphClient, 'query')
+				.withArgs(gql.getDripsReceiverSeenEventsByReceiverId, { receiverId })
+				.resolves({
+					data: {
+						dripsReceiverSeenEvents
+					}
+				});
+			// Act
+			const squeezableSenders = await testSubgraphClient.getSqueezableSenders(receiverId);
+
+			// Assert
+			assert.equal(squeezableSenders['1'].length, 2);
+			assert.equal(squeezableSenders['2'].length, 2);
+			assert.equal(squeezableSenders['3'].length, 2);
+			assert.equal(Object.keys(squeezableSenders).length, 3);
+			assert.equal(getAllUserAssetConfigsByUserIdStub.callCount, 6);
+			assert(
+				queryStub.calledOnceWithExactly(gql.getDripsReceiverSeenEventsByReceiverId, { receiverId }),
 				'Expected method to be called with different arguments'
 			);
 		});


### PR DESCRIPTION
Hey @gh0stwheel!
 
Based on our discussions, this PR implements three methods for supporting MVP - squeezing.

Feel free to ignore all other changes and focus only on the algorithm logic in the following methods:
- `AddressDriverClient.squeezeDrips` https://github.com/radicle-dev/drips-js-sdk/blob/93221b6b51788e993246c8c1e31131408ff91336/src/AddressDriver/AddressDriverClient.ts#L370
- `AddressDriverClient.squeezeDripsFromHistory` https://github.com/radicle-dev/drips-js-sdk/blob/93221b6b51788e993246c8c1e31131408ff91336/src/AddressDriver/AddressDriverClient.ts#L329
- `DripsSubgraphClient.getSqueezableSenders` https://github.com/radicle-dev/drips-js-sdk/blob/93221b6b51788e993246c8c1e31131408ff91336/src/DripsSubgraph/DripsSubgraphClient.ts#L134

Because the algorithm's logic is complex enough to forget in the future, I've included comments within the code to facilitate the code review.
(As we've said, the algorithms' performance is _not_ a priority now, given the small input)

I am looking forward to your feedback!