### PR TITLE
Refactor DripsHubClient's balances API

### DIFF
--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -31,7 +31,7 @@ export default class AddressDriverClient {
 
 	#signer!: JsonRpcSigner;
 	/**
-	 * Returns the user.
+	 * Returns the `AddressDriverClient`'s `signer`.
 	 *
 	 * This is the user to which the `AddressDriverClient` is linked and manages Drips.
 	 *

--- a/src/DripsHub/types.ts
+++ b/src/DripsHub/types.ts
@@ -1,5 +1,3 @@
-import type { ReceivableDrips } from 'src/common/types';
-
 export type DripsState = {
 	/** The current drips receivers list hash. */
 	dripsHash: string;
@@ -13,7 +11,13 @@ export type DripsState = {
 	maxEnd: number;
 };
 
-export type ReceivableTokenBalance = {
+export type ReceivableDrips = {
+	/** The token address. */
 	tokenAddress: string;
-	receivableDrips: ReceivableDrips;
+
+	/** The amount which would be received. */
+	receivableAmt: bigint;
+
+	/** The number of cycles which would still be receivable after the call. */
+	receivableCycles: number;
 };

--- a/src/DripsHub/types.ts
+++ b/src/DripsHub/types.ts
@@ -11,13 +11,31 @@ export type DripsState = {
 	maxEnd: number;
 };
 
-export type ReceivableDrips = {
+export type ReceivableBalance = {
 	/** The token address. */
 	tokenAddress: string;
 
 	/** The amount which would be received. */
-	receivableAmt: bigint;
+	receivableAmount: bigint;
 
-	/** The number of cycles which would still be receivable after the call. */
-	receivableCycles: number;
+	/** The number of cycles that would still be receivable after `receivableAmount` is received. */
+	remainingReceivableCycles: number;
 };
+
+export type SplittableBalance = {
+	/** The token address. */
+	tokenAddress: string;
+
+	/** The amount which would be splitted. */
+	splittableAmount: bigint;
+};
+
+export type CollectableBalance = {
+	/** The token address. */
+	tokenAddress: string;
+
+	/** The amount which would be collected. */
+	collectableAmount: bigint;
+};
+
+export type AssetId = bigint;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -39,10 +39,3 @@ export type CycleInfo = {
 };
 
 export type DripsReceiver = { userId: string; config: DripsReceiverConfig };
-
-export type ReceivableDrips = {
-	/** The amount which would be received. */
-	receivableAmt: bigint;
-	/** The number of cycles which would still be receivable after the call. */
-	receivableCycles: number;
-};

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,5 @@
+export { DripsReceiverStruct, SplitsReceiverStruct } from '../../contracts/DripsHub';
+
 export type DripsReceiverConfig = {
 	/** An arbitrary number used to identify a drip. When setting a config, it must be greater than or equal to `0`. It's a part of the configuration but the protocol doesn't use it. */
 	dripId: bigint;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
 	DripsReceiverStruct,
 	SplitsReceiverStruct
 } from './common/types';
-import { DripsState, ReceivableDrips } from './DripsHub/types';
+import { DripsState, ReceivableBalance, SplittableBalance, CollectableBalance } from './DripsHub/types';
 import {
 	UserAssetConfig,
 	SplitsEntry,
@@ -58,7 +58,9 @@ export {
 	DripsMetadata,
 	DripsReceiver,
 	UserAssetConfig,
-	ReceivableDrips,
+	ReceivableBalance,
+	SplittableBalance,
+	CollectableBalance,
 	DripsReceiverStruct,
 	DripsReceiverConfig,
 	SplitsReceiverStruct,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,10 @@ import {
 	DripsMetadata,
 	CycleInfo,
 	DripsReceiver,
-	ReceivableDrips,
 	DripsReceiverStruct,
 	SplitsReceiverStruct
 } from './common/types';
-import { DripsState, ReceivableTokenBalance } from './DripsHub/types';
+import { DripsState, ReceivableDrips } from './DripsHub/types';
 import {
 	UserAssetConfig,
 	SplitsEntry,
@@ -63,6 +62,5 @@ export {
 	DripsReceiverStruct,
 	DripsReceiverConfig,
 	SplitsReceiverStruct,
-	DripsReceiverSeenEvent,
-	ReceivableTokenBalance
+	DripsReceiverSeenEvent
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-import { DripsReceiverConfig, DripsMetadata, CycleInfo, DripsReceiver, ReceivableDrips } from './common/types';
+import {
+	DripsReceiverConfig,
+	DripsMetadata,
+	CycleInfo,
+	DripsReceiver,
+	ReceivableDrips,
+	DripsReceiverStruct,
+	SplitsReceiverStruct
+} from './common/types';
 import { DripsState, ReceivableTokenBalance } from './DripsHub/types';
 import {
 	UserAssetConfig,
@@ -52,7 +60,9 @@ export {
 	DripsReceiver,
 	UserAssetConfig,
 	ReceivableDrips,
+	DripsReceiverStruct,
 	DripsReceiverConfig,
+	SplitsReceiverStruct,
 	DripsReceiverSeenEvent,
 	ReceivableTokenBalance
 };

--- a/tests/DripsHubClient/DripsHubClient.tests.ts
+++ b/tests/DripsHubClient/DripsHubClient.tests.ts
@@ -1,9 +1,9 @@
 import type { Network } from '@ethersproject/networks';
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 import type { StubbedInstance } from 'ts-sinon';
 import sinon, { stubObject, stubInterface } from 'ts-sinon';
 import { assert } from 'chai';
-import type { BytesLike } from 'ethers';
+import type { BigNumberish, BytesLike } from 'ethers';
 import { BigNumber, Wallet } from 'ethers';
 import DripsHubClient from '../../src/DripsHub/DripsHubClient';
 import type { DripsHub } from '../../contracts';
@@ -11,22 +11,17 @@ import { DripsHub__factory } from '../../contracts';
 import Utils from '../../src/utils';
 import { DripsErrorCode } from '../../src/common/DripsError';
 import * as internals from '../../src/common/internals';
-import type { DripsHistoryStruct, DripsReceiverStruct } from '../../contracts/DripsHub';
+import type { DripsHistoryStruct, DripsReceiverStruct, SplitsReceiverStruct } from '../../contracts/DripsHub';
 import type { DripsReceiverConfig } from '../../src/common/types';
 import DripsSubgraphClient from '../../src/DripsSubgraph/DripsSubgraphClient';
 import type { DripsSetEvent } from '../../src/DripsSubgraph/types';
-import type { ReceivableDrips } from '../../src/DripsHub/types';
+import type { CollectableBalance, ReceivableBalance, SplittableBalance } from '../../src/DripsHub/types';
 
 describe('DripsHubClient', () => {
 	const TEST_CHAIN_ID = 5; // Goerli.
-	const TEST_TOTAL_SPLITS_WEIGHT = 10;
-	const TEST_MAX_DRIPS_RECEIVERS = BigNumber.from(100);
-	const TEST_MAX_SPLITS_RECEIVERS = BigNumber.from(200);
-	const TEST_MAX_TOTAL_BALANCE = BigNumber.from(1);
-	const TEST_AMT_PER_SEC_EXTRA_DECIMALS = 18;
-	const TEST_AMT_PER_SEC_MULTIPLIER = BigNumber.from(1000);
 
 	let networkStub: StubbedInstance<Network>;
+	let signerStub: StubbedInstance<JsonRpcSigner>;
 	let providerStub: StubbedInstance<JsonRpcProvider>;
 	let dripsHubContractStub: StubbedInstance<DripsHub>;
 	let dripsSubgraphClientStub: StubbedInstance<DripsSubgraphClient>;
@@ -36,26 +31,23 @@ describe('DripsHubClient', () => {
 	beforeEach(async () => {
 		providerStub = sinon.createStubInstance(JsonRpcProvider);
 
+		signerStub = sinon.createStubInstance(JsonRpcSigner);
+		signerStub.getAddress.resolves(Wallet.createRandom().address);
+
 		networkStub = stubObject<Network>({ chainId: TEST_CHAIN_ID } as Network);
 
+		providerStub.getSigner.returns(signerStub);
 		providerStub.getNetwork.resolves(networkStub);
 
 		dripsHubContractStub = stubInterface<DripsHub>();
 
 		sinon
 			.stub(DripsHub__factory, 'connect')
-			.withArgs(Utils.Network.dripsMetadata[TEST_CHAIN_ID].CONTRACT_DRIPS_HUB, providerStub)
+			.withArgs(Utils.Network.dripsMetadata[TEST_CHAIN_ID].CONTRACT_DRIPS_HUB, signerStub)
 			.returns(dripsHubContractStub);
 
 		dripsSubgraphClientStub = stubInterface<DripsSubgraphClient>();
 		sinon.stub(DripsSubgraphClient, 'create').returns(dripsSubgraphClientStub);
-
-		dripsHubContractStub.MAX_TOTAL_BALANCE.resolves(TEST_MAX_TOTAL_BALANCE);
-		dripsHubContractStub.TOTAL_SPLITS_WEIGHT.resolves(TEST_TOTAL_SPLITS_WEIGHT);
-		dripsHubContractStub.MAX_DRIPS_RECEIVERS.resolves(TEST_MAX_DRIPS_RECEIVERS);
-		dripsHubContractStub.MAX_SPLITS_RECEIVERS.resolves(TEST_MAX_SPLITS_RECEIVERS);
-		dripsHubContractStub.AMT_PER_SEC_MULTIPLIER.resolves(TEST_AMT_PER_SEC_MULTIPLIER);
-		dripsHubContractStub.AMT_PER_SEC_EXTRA_DECIMALS.resolves(TEST_AMT_PER_SEC_EXTRA_DECIMALS);
 
 		testDripsHubClient = await DripsHubClient.create(providerStub);
 	});
@@ -82,6 +74,38 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
+		it("should throw argumentMissingError error when the provider's signer is missing", async () => {
+			// Arrange
+			let threw = false;
+			providerStub.getSigner.returns(undefined as unknown as JsonRpcSigner);
+
+			try {
+				// Act
+				await DripsHubClient.create(providerStub);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it("should validate the provider's signer address", async () => {
+			// Arrange
+			const validateAddressStub = sinon.stub(internals, 'validateAddress');
+
+			// Act
+			DripsHubClient.create(providerStub);
+
+			// Assert
+			assert(
+				validateAddressStub.calledOnceWithExactly(await signerStub.getAddress()),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should throw unsupportedNetworkError error when the provider is connected to an unsupported network', async () => {
 			// Arrange
 			let threw = false;
@@ -102,36 +126,46 @@ describe('DripsHubClient', () => {
 
 		it('should create a fully initialized client instance', async () => {
 			// Assert
-			assert.equal(testDripsHubClient.network.chainId, TEST_CHAIN_ID);
-			assert.equal((await testDripsHubClient.provider.getNetwork()).chainId, networkStub.chainId);
+			assert.equal(await testDripsHubClient.signer.getAddress(), await signerStub.getAddress());
+			assert.equal(testDripsHubClient.network.chainId, networkStub.chainId);
+			assert.equal(
+				await testDripsHubClient.provider.getSigner().getAddress(),
+				await providerStub.getSigner().getAddress()
+			);
 			assert.equal(
 				testDripsHubClient.dripsMetadata,
 				Utils.Network.dripsMetadata[(await providerStub.getNetwork()).chainId]
 			);
+			assert.equal(testDripsHubClient.signerAddress, await signerStub.getAddress());
 		});
 	});
 
-	describe('getCycleSecs()', () => {
-		it('should call the getCycleSecs() method of the AddressDriver contract', async () => {
+	describe('cycleSecs()', () => {
+		it('should call the cycleSecs() method of the AddressDriver contract', async () => {
 			// Act
-			await testDripsHubClient.getCycleSecs();
+			await testDripsHubClient.cycleSecs();
 
 			// Assert
 			assert(dripsHubContractStub.cycleSecs.calledOnce);
 		});
 	});
 
-	describe('getCycleSecs()', () => {
-		it('should call the getCycleSecs() method of the AddressDriver contract', async () => {
+	describe('cycleSecs()', () => {
+		it('return the expected cycle seconds', async () => {
+			// Arrange
+			const expectedCycleSecs = 10;
+			dripsHubContractStub.cycleSecs.resolves(expectedCycleSecs);
+
 			// Act
-			await testDripsHubClient.getCycleSecs();
+			const actualCycleSecs = await testDripsHubClient.cycleSecs();
 
 			// Assert
+			assert.equal(actualCycleSecs, expectedCycleSecs);
 			assert(dripsHubContractStub.cycleSecs.calledOnce);
 		});
 	});
 
-	describe('getTotalBalanceForToken()', () => {
+	describe('getTokenBalance()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const tokenAddress = Wallet.createRandom().address;
@@ -140,27 +174,29 @@ describe('DripsHubClient', () => {
 			dripsHubContractStub.totalBalance.withArgs(tokenAddress).resolves(BigNumber.from(1));
 
 			// Act
-			await testDripsHubClient.getTotalBalanceForToken(tokenAddress);
+			await testDripsHubClient.getTokenBalance(tokenAddress);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
 		});
 
-		it('should call the totalBalance() method of the AddressDriver contract', async () => {
+		it('return the expected token balance', async () => {
 			// Arrange
+			const expectedBalance = BigNumber.from(10);
 			const tokenAddress = Wallet.createRandom().address;
 
-			dripsHubContractStub.totalBalance.withArgs(tokenAddress).resolves(BigNumber.from(1));
+			dripsHubContractStub.totalBalance.withArgs(tokenAddress).resolves(expectedBalance);
 
 			// Act
-			await testDripsHubClient.getTotalBalanceForToken(tokenAddress);
+			const actualBalance = await testDripsHubClient.getTokenBalance(tokenAddress);
 
 			// Assert
+			assert.equal(actualBalance, expectedBalance.toBigInt());
 			assert(dripsHubContractStub.totalBalance.calledOnceWithExactly(tokenAddress));
 		});
 	});
 
-	describe('getReceivableDripsCyclesCount()', () => {
+	describe('receivableCyclesCount()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -168,7 +204,7 @@ describe('DripsHubClient', () => {
 			const validateAddressStub = sinon.stub(internals, 'validateAddress');
 
 			// Act
-			await testDripsHubClient.getReceivableDripsCyclesCount(userId, tokenAddress);
+			await testDripsHubClient.receivableCyclesCount(userId, tokenAddress);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -181,7 +217,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getReceivableDripsCyclesCount(undefined as unknown as string, tokenAddress);
+				await testDripsHubClient.receivableCyclesCount(undefined as unknown as string, tokenAddress);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -192,20 +228,24 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the receivableDripsCycles() method of the AddressDriver contract', async () => {
+		it('return the expected count', async () => {
 			// Arrange
 			const userId = '1';
+			const expectedCount = 10;
 			const tokenAddress = Wallet.createRandom().address;
 
+			dripsHubContractStub.receivableDripsCycles.withArgs(userId, tokenAddress).resolves(expectedCount);
+
 			// Act
-			await testDripsHubClient.getReceivableDripsCyclesCount(userId, tokenAddress);
+			const actualCount = await testDripsHubClient.receivableCyclesCount(userId, tokenAddress);
 
 			// Assert
+			assert.equal(actualCount, expectedCount);
 			assert(dripsHubContractStub.receivableDripsCycles.calledOnceWithExactly(userId, tokenAddress));
 		});
 	});
 
-	describe('getReceivableDrips()', () => {
+	describe('getReceivableBalanceForUser()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -219,7 +259,7 @@ describe('DripsHubClient', () => {
 			} as any);
 
 			// Act
-			await testDripsHubClient.getReceivableDrips(userId, tokenAddress, maxCycles);
+			await testDripsHubClient.getReceivableBalanceForUser(userId, tokenAddress, maxCycles);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -232,7 +272,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getReceivableDrips(undefined as unknown as string, tokenAddress, 1);
+				await testDripsHubClient.getReceivableBalanceForUser(undefined as unknown as string, tokenAddress, 1);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -250,7 +290,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getReceivableDrips('1', tokenAddress, undefined as unknown as number);
+				await testDripsHubClient.getReceivableBalanceForUser('1', tokenAddress, undefined as unknown as number);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
@@ -261,24 +301,125 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the receivableDrips() method of the AddressDriver contract', async () => {
+		it('should return the expected receivable balance', async () => {
 			// Arrange
 			const userId = '1';
 			const maxCycles = 1;
 			const tokenAddress = Wallet.createRandom().address;
-
-			dripsHubContractStub.receiveDripsResult.withArgs(userId, tokenAddress, maxCycles).resolves({
+			const expectedBalance = {
 				receivableAmt: BigNumber.from(1),
 				receivableCycles: 1
-			} as any);
+			} as [BigNumber, number] & { receivableAmt: BigNumber; receivableCycles: number };
+
+			dripsHubContractStub.receiveDripsResult.withArgs(userId, tokenAddress, maxCycles).resolves(expectedBalance);
 
 			// Act
-			const receivableDrips = await testDripsHubClient.getReceivableDrips(userId, tokenAddress, maxCycles);
+			const actualBalance = await testDripsHubClient.getReceivableBalanceForUser(userId, tokenAddress, maxCycles);
 
 			// Assert
-			assert.equal(receivableDrips.receivableAmt, 1n);
-			assert.equal(receivableDrips.receivableCycles, 1);
+			assert.equal(actualBalance.receivableAmount, expectedBalance.receivableAmt.toBigInt());
+			assert.equal(actualBalance.remainingReceivableCycles, expectedBalance.receivableCycles);
 			assert(dripsHubContractStub.receiveDripsResult.calledOnceWithExactly(userId, tokenAddress, maxCycles));
+		});
+	});
+
+	describe('getAllReceivableBalancesForUser()', () => {
+		it('should throw argumentMissingError when userId is missing', async () => {
+			// Arrange
+			let threw = false;
+
+			try {
+				// Act
+				await testDripsHubClient.getAllReceivableBalancesForUser(undefined as unknown as string);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should throw argumentError when maxCycles is less than 0', async () => {
+			// Arrange
+			let threw = false;
+
+			try {
+				// Act
+				await testDripsHubClient.getAllReceivableBalancesForUser('1', -1);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should return an empty array when there are no tokens found for the user', async () => {
+			// Arrange
+			const userId = '1';
+			const maxCycles = 10;
+
+			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves([]);
+
+			// Act
+			const balances = await testDripsHubClient.getAllReceivableBalancesForUser(userId, maxCycles);
+
+			// Assert
+			assert.isEmpty(balances);
+		});
+
+		it('should return the expected receivable balances', async () => {
+			// Arrange
+			const userId = '1';
+			const maxCycles = 10;
+			const tokenAddress1 = Wallet.createRandom().address;
+			const tokenAddress2 = Wallet.createRandom().address;
+
+			const dripsSetEvents: DripsSetEvent[] = [
+				{
+					assetId: Utils.Asset.getIdFromAddress(tokenAddress1)
+				} as DripsSetEvent,
+				{
+					assetId: Utils.Asset.getIdFromAddress(tokenAddress2)
+				} as DripsSetEvent
+			];
+
+			const receivableDrips: ReceivableBalance[] = [
+				{
+					tokenAddress: tokenAddress1,
+					receivableAmount: BigInt(1),
+					remainingReceivableCycles: 1
+				},
+				{
+					tokenAddress: tokenAddress2,
+					receivableAmount: BigInt(2),
+					remainingReceivableCycles: 2
+				}
+			];
+
+			sinon
+				.stub(DripsHubClient.prototype, 'getReceivableBalanceForUser')
+				.onFirstCall()
+				.resolves(receivableDrips[0])
+				.onSecondCall()
+				.resolves(receivableDrips[1]);
+
+			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves(dripsSetEvents);
+
+			// Act
+			const balances = await testDripsHubClient.getAllReceivableBalancesForUser(userId, maxCycles);
+
+			// Assert
+			assert.equal(balances[0].tokenAddress, Utils.Asset.getAddressFromId(dripsSetEvents[0].assetId));
+			assert.equal(balances[0].receivableAmount, receivableDrips[0].receivableAmount);
+			assert.equal(balances[0].remainingReceivableCycles, receivableDrips[0].remainingReceivableCycles);
+			assert.equal(balances[1].tokenAddress, Utils.Asset.getAddressFromId(dripsSetEvents[1].assetId));
+			assert.equal(balances[1].receivableAmount, receivableDrips[1].receivableAmount);
+			assert.equal(balances[1].remainingReceivableCycles, receivableDrips[1].remainingReceivableCycles);
 		});
 	});
 
@@ -347,7 +488,7 @@ describe('DripsHubClient', () => {
 		});
 	});
 
-	describe('getSqueezableDrips()', () => {
+	describe('getSqueezableBalance()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -362,7 +503,7 @@ describe('DripsHubClient', () => {
 				.resolves(BigNumber.from(1));
 
 			// Act
-			await testDripsHubClient.getSqueezableDrips(userId, tokenAddress, senderId, historyHash, dripsHistory);
+			await testDripsHubClient.getSqueezableBalance(userId, tokenAddress, senderId, historyHash, dripsHistory);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -375,7 +516,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getSqueezableDrips(undefined as unknown as string, tokenAddress, '1', '', []);
+				await testDripsHubClient.getSqueezableBalance(undefined as unknown as string, tokenAddress, '1', '', []);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -393,7 +534,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getSqueezableDrips('1', tokenAddress, undefined as unknown as string, '', []);
+				await testDripsHubClient.getSqueezableBalance('1', tokenAddress, undefined as unknown as string, '', []);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -411,7 +552,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getSqueezableDrips('1', tokenAddress, '1', undefined as unknown as BytesLike, []);
+				await testDripsHubClient.getSqueezableBalance('1', tokenAddress, '1', undefined as unknown as BytesLike, []);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -429,7 +570,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getSqueezableDrips(
+				await testDripsHubClient.getSqueezableBalance(
 					'1',
 					tokenAddress,
 					'1',
@@ -446,22 +587,30 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the squeezeDripsResult() method of the AddressDriver contract', async () => {
+		it('should return the expected squeezable balance', async () => {
 			// Arrange
 			const userId = '1';
 			const senderId = '1';
 			const historyHash = '0x';
+			const expectedBalance = BigNumber.from(10);
 			const dripsHistory: DripsHistoryStruct[] = [];
 			const tokenAddress = Wallet.createRandom().address;
 
 			dripsHubContractStub.squeezeDripsResult
 				.withArgs(userId, tokenAddress, senderId, historyHash, dripsHistory)
-				.resolves(BigNumber.from(1));
+				.resolves(expectedBalance);
 
 			// Act
-			await testDripsHubClient.getSqueezableDrips(userId, tokenAddress, senderId, historyHash, dripsHistory);
+			const actualBalance = await testDripsHubClient.getSqueezableBalance(
+				userId,
+				tokenAddress,
+				senderId,
+				historyHash,
+				dripsHistory
+			);
 
 			// Assert
+			assert.equal(actualBalance, expectedBalance.toBigInt());
 			assert(
 				dripsHubContractStub.squeezeDripsResult.calledOnceWithExactly(
 					userId,
@@ -474,7 +623,7 @@ describe('DripsHubClient', () => {
 		});
 	});
 
-	describe('getSplittable()', () => {
+	describe('getSplittableBalanceForUser()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -484,7 +633,7 @@ describe('DripsHubClient', () => {
 			dripsHubContractStub.splittable.withArgs(userId, tokenAddress).resolves(BigNumber.from(1));
 
 			// Act
-			await testDripsHubClient.getSplittable(userId, tokenAddress);
+			await testDripsHubClient.getSplittableBalanceForUser(userId, tokenAddress);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -497,7 +646,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getSplittable(undefined as unknown as string, tokenAddress);
+				await testDripsHubClient.getSplittableBalanceForUser(undefined as unknown as string, tokenAddress);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -508,22 +657,264 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the splittable() method of the AddressDriver contract', async () => {
+		it('should return the expected splittable balance', async () => {
 			// Arrange
 			const userId = '1';
 			const tokenAddress = Wallet.createRandom().address;
+			const expectedBalance = BigNumber.from(10);
 
-			dripsHubContractStub.splittable.withArgs(userId, tokenAddress).resolves(BigNumber.from(1));
+			dripsHubContractStub.splittable.withArgs(userId, tokenAddress).resolves(expectedBalance);
 
 			// Act
-			await testDripsHubClient.getSplittable(userId, tokenAddress);
+			const actualBalance = await testDripsHubClient.getSplittableBalanceForUser(userId, tokenAddress);
 
 			// Assert
+			assert.equal(actualBalance.tokenAddress, tokenAddress);
+			assert.equal(actualBalance.splittableAmount, expectedBalance.toBigInt());
 			assert(dripsHubContractStub.splittable.calledOnceWithExactly(userId, tokenAddress));
 		});
 	});
 
-	describe('getCollectable()', () => {
+	describe('getAllSplittableBalancesForUser()', () => {
+		it('should throw argumentMissingError when userId is missing', async () => {
+			// Arrange
+			let threw = false;
+
+			try {
+				// Act
+				await testDripsHubClient.getAllSplittableBalancesForUser(undefined as unknown as string);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should return an empty array when there are no tokens found for the user', async () => {
+			// Arrange
+			const userId = '1';
+
+			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves([]);
+
+			// Act
+			const balances = await testDripsHubClient.getAllSplittableBalancesForUser(userId);
+
+			// Assert
+			assert.isEmpty(balances);
+		});
+
+		it('should return the expected splittable balances', async () => {
+			// Arrange
+			const userId = '1';
+			const tokenAddress1 = Wallet.createRandom().address;
+			const tokenAddress2 = Wallet.createRandom().address;
+
+			const dripsSetEvents: DripsSetEvent[] = [
+				{
+					assetId: Utils.Asset.getIdFromAddress(tokenAddress1)
+				} as DripsSetEvent,
+				{
+					assetId: Utils.Asset.getIdFromAddress(tokenAddress2)
+				} as DripsSetEvent
+			];
+
+			const splittableBalances: SplittableBalance[] = [
+				{
+					tokenAddress: tokenAddress1,
+					splittableAmount: 1n
+				},
+				{
+					tokenAddress: tokenAddress2,
+					splittableAmount: 2n
+				}
+			];
+
+			sinon
+				.stub(DripsHubClient.prototype, 'getSplittableBalanceForUser')
+				.onFirstCall()
+				.resolves(splittableBalances[0])
+				.onSecondCall()
+				.resolves(splittableBalances[1]);
+
+			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves(dripsSetEvents);
+
+			// Act
+			const balances = await testDripsHubClient.getAllSplittableBalancesForUser(userId);
+
+			// Assert
+			assert.equal(balances[0].splittableAmount, splittableBalances[0].splittableAmount);
+			assert.equal(balances[0].tokenAddress, splittableBalances[0].tokenAddress);
+			assert.equal(balances[1].splittableAmount, splittableBalances[1].splittableAmount);
+			assert.equal(balances[1].tokenAddress, splittableBalances[1].tokenAddress);
+		});
+	});
+
+	describe('getSplitResult', () => {
+		it('validate split receivers', async () => {
+			// Arrange
+			const receivers: SplitsReceiverStruct[] = [
+				{ userId: 1, weight: 1 },
+				{ userId: 2, weight: 2 }
+			];
+
+			const validateSplitsReceiversStub = sinon.stub(internals, 'validateSplitsReceivers');
+
+			dripsHubContractStub.splitResult.withArgs('1', receivers, 1).resolves(BigNumber.from(0));
+
+			// Act
+			await testDripsHubClient.getSplitResult('1', receivers, 1);
+
+			// Assert
+			assert(validateSplitsReceiversStub.calledOnceWithExactly(receivers));
+		});
+
+		it('should throw an argumentMissingError when user ID is missing', async () => {
+			// Arrange
+			let threw = false;
+
+			// Act
+			try {
+				await testDripsHubClient.getSplitResult(undefined as unknown as string, [], 1);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should throw an argumentError when amount is missing', async () => {
+			// Arrange
+			let threw = false;
+
+			// Act
+			try {
+				await testDripsHubClient.getSplitResult('1', [], undefined as unknown as BigNumberish);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should throw an argumentError when amount is less than 0', async () => {
+			// Arrange
+			let threw = false;
+
+			// Act
+			try {
+				await testDripsHubClient.getSplitResult('1', [], -1);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should return the expected split result', async () => {
+			// Arrange
+			const amount = 1;
+			const userId = '1';
+			const expectedAmountLeft = BigNumber.from(10);
+			const currentReceivers: SplitsReceiverStruct[] = [];
+
+			dripsHubContractStub.splitResult.withArgs(userId, currentReceivers, amount).resolves(expectedAmountLeft);
+
+			// Act
+			const actualAmountLeft = await testDripsHubClient.getSplitResult(userId, currentReceivers, amount);
+
+			// Assert
+			assert.equal(actualAmountLeft, expectedAmountLeft.toBigInt());
+			assert(dripsHubContractStub.splitResult.calledOnceWithExactly(userId, currentReceivers, amount));
+		});
+	});
+
+	describe('split', () => {
+		it('should throw argumentMissingError when splits receivers are missing', async () => {
+			// Arrange
+			let threw = false;
+
+			// Act
+			try {
+				await testDripsHubClient.split(undefined as unknown as BigNumberish, Wallet.createRandom().address, []);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should validate the splits receivers', async () => {
+			// Arrange
+			const userId = '1';
+			const tokenAddress = Wallet.createRandom().address;
+			const receivers: SplitsReceiverStruct[] = [
+				{ userId: 1, weight: 1 },
+				{ userId: 2, weight: 2 }
+			];
+
+			const validateSplitsReceiversStub = sinon.stub(internals, 'validateSplitsReceivers');
+
+			// Act
+			await testDripsHubClient.split(userId, tokenAddress, receivers);
+
+			// Assert
+			assert(validateSplitsReceiversStub.calledOnceWithExactly(receivers));
+		});
+
+		it('should validate the ERC20 address', async () => {
+			// Arrange
+			const userId = '1';
+			const tokenAddress = Wallet.createRandom().address;
+			const receivers: SplitsReceiverStruct[] = [
+				{ userId: 1, weight: 1 },
+				{ userId: 2, weight: 2 }
+			];
+
+			const validateSplitsReceiversStub = sinon.stub(internals, 'validateSplitsReceivers');
+
+			// Act
+			await testDripsHubClient.split(userId, tokenAddress, receivers);
+
+			// Assert
+			assert(validateSplitsReceiversStub.calledOnceWithExactly(receivers));
+		});
+
+		it('should call the setDrips() method of the AddressDriver contract', async () => {
+			// Arrange
+			const userId = '1';
+			const tokenAddress = Wallet.createRandom().address;
+			const receivers: SplitsReceiverStruct[] = [
+				{ userId: 1, weight: 1 },
+				{ userId: 2, weight: 2 }
+			];
+
+			// Act
+			await testDripsHubClient.split(userId, tokenAddress, receivers);
+
+			// Assert
+			assert(
+				dripsHubContractStub.split.calledOnceWithExactly(userId, tokenAddress, receivers),
+				'Expected method to be called with different arguments'
+			);
+		});
+	});
+
+	describe('getCollectableBalanceForUser()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -533,7 +924,7 @@ describe('DripsHubClient', () => {
 			dripsHubContractStub.collectable.withArgs(userId, tokenAddress).resolves(BigNumber.from(1));
 
 			// Act
-			await testDripsHubClient.getCollectable(userId, tokenAddress);
+			await testDripsHubClient.getCollectableBalanceForUser(userId, tokenAddress);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -546,7 +937,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getCollectable(undefined as unknown as string, tokenAddress);
+				await testDripsHubClient.getCollectableBalanceForUser(undefined as unknown as string, tokenAddress);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -557,22 +948,102 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the collectable() method of the AddressDriver contract', async () => {
+		it('should return the expected collectable balance', async () => {
 			// Arrange
 			const userId = '1';
+			const expectedBalance = BigNumber.from(1);
 			const tokenAddress = Wallet.createRandom().address;
 
-			dripsHubContractStub.collectable.withArgs(userId, tokenAddress).resolves(BigNumber.from(1));
+			dripsHubContractStub.collectable.withArgs(userId, tokenAddress).resolves(expectedBalance);
 
 			// Act
-			await testDripsHubClient.getCollectable(userId, tokenAddress);
+			const actualBalance = await testDripsHubClient.getCollectableBalanceForUser(userId, tokenAddress);
 
 			// Assert
+			assert.equal(actualBalance.tokenAddress, tokenAddress);
+			assert.equal(actualBalance.collectableAmount, expectedBalance.toBigInt());
 			assert(dripsHubContractStub.collectable.calledOnceWithExactly(userId, tokenAddress));
 		});
 	});
 
-	describe('getDripsState()', () => {
+	describe('getAllCollectableBalancesForUser()', () => {
+		it('should throw argumentMissingError when userId is missing', async () => {
+			// Arrange
+			let threw = false;
+
+			try {
+				// Act
+				await testDripsHubClient.getAllCollectableBalancesForUser(undefined as unknown as string);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should return an empty array when there are no tokens found for the user', async () => {
+			// Arrange
+			const userId = '1';
+
+			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves([]);
+
+			// Act
+			const balances = await testDripsHubClient.getAllCollectableBalancesForUser(userId);
+
+			// Assert
+			assert.isEmpty(balances);
+		});
+
+		it('should return the expected collectable balances', async () => {
+			// Arrange
+			const userId = '1';
+			const tokenAddress1 = Wallet.createRandom().address;
+			const tokenAddress2 = Wallet.createRandom().address;
+
+			const dripsSetEvents: DripsSetEvent[] = [
+				{
+					assetId: Utils.Asset.getIdFromAddress(tokenAddress1)
+				} as DripsSetEvent,
+				{
+					assetId: Utils.Asset.getIdFromAddress(tokenAddress2)
+				} as DripsSetEvent
+			];
+
+			const collectableBalances: CollectableBalance[] = [
+				{
+					tokenAddress: tokenAddress1,
+					collectableAmount: 1n
+				},
+				{
+					tokenAddress: tokenAddress2,
+					collectableAmount: 2n
+				}
+			];
+
+			sinon
+				.stub(DripsHubClient.prototype, 'getCollectableBalanceForUser')
+				.onFirstCall()
+				.resolves(collectableBalances[0])
+				.onSecondCall()
+				.resolves(collectableBalances[1]);
+
+			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves(dripsSetEvents);
+
+			// Act
+			const balances = await testDripsHubClient.getAllCollectableBalancesForUser(userId);
+
+			// Assert
+			assert.equal(balances[0].collectableAmount, collectableBalances[0].collectableAmount);
+			assert.equal(balances[0].tokenAddress, collectableBalances[0].tokenAddress);
+			assert.equal(balances[1].collectableAmount, collectableBalances[1].collectableAmount);
+			assert.equal(balances[1].tokenAddress, collectableBalances[1].tokenAddress);
+		});
+	});
+
+	describe('dripsState()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -582,7 +1053,7 @@ describe('DripsHubClient', () => {
 			dripsHubContractStub.dripsState.withArgs(userId, tokenAddress).resolves({} as any);
 
 			// Act
-			await testDripsHubClient.getDripsState(userId, tokenAddress);
+			await testDripsHubClient.dripsState(userId, tokenAddress);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -595,7 +1066,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getDripsState(undefined as unknown as string, tokenAddress);
+				await testDripsHubClient.dripsState(undefined as unknown as string, tokenAddress);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -606,22 +1077,34 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the dripsState() method of the AddressDriver contract', async () => {
+		it('should return the expected user state', async () => {
 			// Arrange
 			const userId = '1';
+			const expectedState = {
+				dripsHash: '0x00',
+				dripsHistoryHash: '0x01',
+				updateTime: 1,
+				balance: BigNumber.from(2),
+				maxEnd: 3
+			} as any;
 			const tokenAddress = Wallet.createRandom().address;
 
-			dripsHubContractStub.dripsState.withArgs(userId, tokenAddress).resolves({} as any);
+			dripsHubContractStub.dripsState.withArgs(userId, tokenAddress).resolves(expectedState);
 
 			// Act
-			await testDripsHubClient.getDripsState(userId, tokenAddress);
+			const actualState = await testDripsHubClient.dripsState(userId, tokenAddress);
 
 			// Assert
+			assert.equal(actualState.maxEnd, expectedState.maxEnd);
+			assert.equal(actualState.balance, expectedState.balance.toBigInt());
+			assert.equal(actualState.dripsHash, expectedState.dripsHash);
+			assert.equal(actualState.updateTime, expectedState.updateTime);
+			assert.equal(actualState.dripsHistoryHash, expectedState.dripsHistoryHash);
 			assert(dripsHubContractStub.dripsState.calledOnceWithExactly(userId, tokenAddress));
 		});
 	});
 
-	describe('getBalanceAt()', () => {
+	describe('getDripsBalanceAt()', () => {
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const userId = '1';
@@ -630,8 +1113,10 @@ describe('DripsHubClient', () => {
 			const tokenAddress = Wallet.createRandom().address;
 			const validateAddressStub = sinon.stub(internals, 'validateAddress');
 
+			dripsHubContractStub.balanceAt.withArgs(userId, tokenAddress, receivers, timestamp).resolves(BigNumber.from(1));
+
 			// Act
-			await testDripsHubClient.getBalanceAt(userId, tokenAddress, receivers, timestamp);
+			await testDripsHubClient.getDripsBalanceAt(userId, tokenAddress, receivers, timestamp);
 
 			// Assert
 			assert(validateAddressStub.calledOnceWithExactly(tokenAddress));
@@ -650,8 +1135,10 @@ describe('DripsHubClient', () => {
 			const tokenAddress = Wallet.createRandom().address;
 			const validateDripsReceiversStub = sinon.stub(internals, 'validateDripsReceivers');
 
+			dripsHubContractStub.balanceAt.withArgs(userId, tokenAddress, receivers, timestamp).resolves(BigNumber.from(1));
+
 			// Act
-			await testDripsHubClient.getBalanceAt(userId, tokenAddress, receivers, timestamp);
+			await testDripsHubClient.getDripsBalanceAt(userId, tokenAddress, receivers, timestamp);
 
 			// Assert
 			assert(
@@ -671,7 +1158,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getBalanceAt(undefined as unknown as string, tokenAddress, [], 1n);
+				await testDripsHubClient.getDripsBalanceAt(undefined as unknown as string, tokenAddress, [], 1n);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -689,7 +1176,7 @@ describe('DripsHubClient', () => {
 
 			try {
 				// Act
-				await testDripsHubClient.getBalanceAt('1', tokenAddress, [], undefined as unknown as bigint);
+				await testDripsHubClient.getDripsBalanceAt('1', tokenAddress, [], undefined as unknown as bigint);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -700,7 +1187,7 @@ describe('DripsHubClient', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it('should call the balanceAt() method of the AddressDriver contract', async () => {
+		it('should return the expected result', async () => {
 			// Arrange
 			const userId = '1';
 			const timestamp = 11111n;
@@ -711,112 +1198,16 @@ describe('DripsHubClient', () => {
 					config: Utils.DripsReceiverConfiguration.toUint256({ dripId: 1n, amountPerSec: 1n, duration: 1n, start: 1n })
 				}
 			];
+			const expectedBalance = BigNumber.from(1);
+
+			dripsHubContractStub.balanceAt.withArgs(userId, tokenAddress, receivers, timestamp).resolves(expectedBalance);
 
 			// Act
-			await testDripsHubClient.getBalanceAt(userId, tokenAddress, receivers, timestamp);
+			const actualBalance = await testDripsHubClient.getDripsBalanceAt(userId, tokenAddress, receivers, timestamp);
 
 			// Assert
+			assert.equal(actualBalance, expectedBalance.toBigInt());
 			assert(dripsHubContractStub.balanceAt.calledOnceWithExactly(userId, tokenAddress, receivers, timestamp));
-		});
-	});
-
-	describe('getAllReceivableBalancesForUser()', () => {
-		it('should throw argumentMissingError when userId is missing', async () => {
-			// Arrange
-			let threw = false;
-
-			try {
-				// Act
-				await testDripsHubClient.getAllReceivableBalancesForUser(undefined as unknown as string);
-			} catch (error: any) {
-				// Assert
-				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
-				threw = true;
-			}
-
-			// Assert
-			assert.isTrue(threw, 'Expected type of exception was not thrown');
-		});
-
-		it('should throw argumentError when maxCycles is less than 0', async () => {
-			// Arrange
-			let threw = false;
-
-			try {
-				// Act
-				await testDripsHubClient.getAllReceivableBalancesForUser('1', -1);
-			} catch (error: any) {
-				// Assert
-				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
-				threw = true;
-			}
-
-			// Assert
-			assert.isTrue(threw, 'Expected type of exception was not thrown');
-		});
-
-		it('should return an empty array when there are no DripSet events for the user', async () => {
-			// Arrange
-			const userId = '1';
-			const maxCycles = 10;
-
-			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves([]);
-
-			// Act
-			const balances = await testDripsHubClient.getAllReceivableBalancesForUser(userId, maxCycles);
-
-			// Assert
-			assert.isEmpty(balances);
-		});
-
-		it('should return the expected result', async () => {
-			// Arrange
-			const userId = '1';
-			const maxCycles = 10;
-			const tokenAddress1 = Wallet.createRandom().address;
-			const tokenAddress2 = Wallet.createRandom().address;
-
-			const dripsSetEvents: DripsSetEvent[] = [
-				{
-					assetId: Utils.Asset.getIdFromAddress(tokenAddress1)
-				} as DripsSetEvent,
-				{
-					assetId: Utils.Asset.getIdFromAddress(tokenAddress2)
-				} as DripsSetEvent
-			];
-
-			const receivableDrips: ReceivableDrips[] = [
-				{
-					tokenAddress: tokenAddress1,
-					receivableAmt: BigInt(1),
-					receivableCycles: 1
-				},
-				{
-					tokenAddress: tokenAddress2,
-					receivableAmt: BigInt(2),
-					receivableCycles: 2
-				}
-			];
-
-			sinon
-				.stub(DripsHubClient.prototype, 'getReceivableDrips')
-				.onFirstCall()
-				.resolves(receivableDrips[0])
-				.onSecondCall()
-				.resolves(receivableDrips[1]);
-
-			dripsSubgraphClientStub.getDripsSetEventsByUserId.withArgs(userId).resolves(dripsSetEvents);
-
-			// Act
-			const balances = await testDripsHubClient.getAllReceivableBalancesForUser(userId, maxCycles);
-
-			// Assert
-			assert.equal(balances[0].tokenAddress, Utils.Asset.getAddressFromId(dripsSetEvents[0].assetId));
-			assert.equal(balances[0].receivableAmt, receivableDrips[0].receivableAmt);
-			assert.equal(balances[0].receivableCycles, receivableDrips[0].receivableCycles);
-			assert.equal(balances[1].tokenAddress, Utils.Asset.getAddressFromId(dripsSetEvents[1].assetId));
-			assert.equal(balances[1].receivableAmt, receivableDrips[1].receivableAmt);
-			assert.equal(balances[1].receivableCycles, receivableDrips[1].receivableCycles);
 		});
 	});
 });


### PR DESCRIPTION
- Rename API methods to be more clear
- Add methods for getting collectable and splittable balances
- Add method for simulating splitting and "real" splitting
- Fix bug causing "writable" methods to fail
- Improve documentation
- generic improvements