### PR TITLE
Change token ID type

### DIFF
--- a/src/NFTDriver/NFTDriverClient.ts
+++ b/src/NFTDriver/NFTDriverClient.ts
@@ -175,7 +175,7 @@ export default class NFTDriverClient {
 	 * @throws {DripsErrors.argumentMissingError} if the `transferToAddress` is missing.
 	 * @throws {DripsErrors.addressError} if the `transferToAddress` is not valid.
 	 */
-	public async mint(transferToAddress: string): Promise<bigint> {
+	public async mint(transferToAddress: string): Promise<string> {
 		if (!transferToAddress) {
 			throw DripsErrors.argumentMissingError(
 				`Could not mint: '${nameOf({ transferToAddress })}' is missing.`,
@@ -191,7 +191,7 @@ export default class NFTDriverClient {
 		const [transferEvent] = txReceipt.events!;
 		const { tokenId } = transferEvent.args!;
 
-		return BigInt(tokenId);
+		return BigInt(tokenId).toString();
 	}
 
 	/**
@@ -201,7 +201,7 @@ export default class NFTDriverClient {
 	 * @throws {DripsErrors.argumentMissingError} if the `transferToAddress` is missing.
 	 * @throws {DripsErrors.addressError} if the `transferToAddress` is not valid.
 	 */
-	public async safeMint(transferToAddress: string): Promise<bigint> {
+	public async safeMint(transferToAddress: string): Promise<string> {
 		if (!transferToAddress) {
 			throw DripsErrors.argumentMissingError(
 				`Could not (safely) mint: '${nameOf({ transferToAddress })}' is missing.`,
@@ -217,14 +217,14 @@ export default class NFTDriverClient {
 		const [transferEvent] = txReceipt.events!;
 		const { tokenId } = transferEvent.args!;
 
-		return BigInt(tokenId);
+		return BigInt(tokenId).toString();
 	}
 
 	// TODO: Add squeezing support.
 
 	/**
 	 * Collects the received and already split funds and transfers them from the `DripsHub` smart contract to an address.
-	 * @param  {BigNumberish} tokenId The ID of the token representing the collecting user ID.
+	 * @param  {string} tokenId The ID of the token representing the collecting user ID.
 	 * The token ID is equal to the user ID controlled by it.
 	 * @param  {string} tokenAddress The ERC20 token address.
 	 * @param  {string} transferToAddress The address to send collected funds to.
@@ -232,11 +232,7 @@ export default class NFTDriverClient {
 	 * @throws {DripsErrors.argumentMissingError} if the `tokenId` is missing.
 	 * @throws {DripsErrors.addressError} if `tokenAddress` or `transferToAddress` is not valid.
 	 */
-	public async collect(
-		tokenId: BigNumberish,
-		tokenAddress: string,
-		transferToAddress: string
-	): Promise<ContractTransaction> {
+	public async collect(tokenId: string, tokenAddress: string, transferToAddress: string): Promise<ContractTransaction> {
 		if (isNullOrUndefined(tokenId)) {
 			throw DripsErrors.argumentMissingError(
 				`Could not collect '${nameOf({ tokenId })}' is missing.`,
@@ -254,7 +250,7 @@ export default class NFTDriverClient {
 	 * Gives funds to the receiver.
 	 * The receiver can collect them immediately.
 	 * Transfers funds from the user's wallet to the `DripsHub` smart contract.
-	 * @param  {BigNumberish} tokenId The ID of the token representing the giving user.
+	 * @param  {string} tokenId The ID of the token representing the giving user.
 	 * The token ID is equal to the user ID controlled by it.
 	 * @param  {string} receiverUserId The receiver user ID.
 	 * @param  {string} tokenAddress The ERC20 token address.
@@ -265,7 +261,7 @@ export default class NFTDriverClient {
 	 * @throws {DripsErrors.argumentError} if the `amount` is less than or equal to `0`.
 	 */
 	public give(
-		tokenId: BigNumberish,
+		tokenId: string,
 		receiverUserId: string,
 		tokenAddress: string,
 		amount: BigNumberish
@@ -300,7 +296,7 @@ export default class NFTDriverClient {
 	/**
 	 * Sets a drips configuration.
 	 * Transfers funds from the user's wallet to the `DripsHub` smart contract to fulfill the change of the drips balance.
-	 * @param  {BigNumberish} tokenId The ID of the token representing the configured user ID.
+	 * @param  {string} tokenId The ID of the token representing the configured user ID.
 	 * The token ID is equal to the user ID controlled by it.
 	 * @param  {string} tokenAddress The ERC20 token address.
 	 * @param  {DripsReceiverStruct[]} currentReceivers The drips receivers that were set in the last drips update.
@@ -322,7 +318,7 @@ export default class NFTDriverClient {
 	 * @throws {DripsErrors.dripsReceiverConfigError} if any of the receivers' configuration is not valid.
 	 */
 	public setDrips(
-		tokenId: BigNumberish,
+		tokenId: string,
 		tokenAddress: string,
 		currentReceivers: DripsReceiverStruct[],
 		newReceivers: DripsReceiverStruct[],
@@ -371,7 +367,7 @@ export default class NFTDriverClient {
 
 	/**
 	 * Sets the splits configuration.
-	 * @param  {BigNumberish} tokenId The ID of the token representing the configured user ID.
+	 * @param  {string} tokenId The ID of the token representing the configured user ID.
 	 * The token ID is equal to the user ID controlled by it.
 	 * @param  {SplitsReceiverStruct[]} receivers The splits receivers (max `200`).
 	 * Each splits receiver will be getting `weight / TOTAL_SPLITS_WEIGHT` share of the funds.
@@ -382,7 +378,7 @@ export default class NFTDriverClient {
 	 * @throws {DripsErrors.argumentError} if `receivers`' count exceeds the max allowed splits receivers.
 	 * @throws {DripsErrors.splitsReceiverError} if any of the `receivers` is not valid.
 	 */
-	public setSplits(tokenId: BigNumberish, receivers: SplitsReceiverStruct[]): Promise<ContractTransaction> {
+	public setSplits(tokenId: string, receivers: SplitsReceiverStruct[]): Promise<ContractTransaction> {
 		if (isNullOrUndefined(tokenId)) {
 			throw DripsErrors.argumentMissingError(
 				`Could not set splits: '${nameOf({ tokenId })}' is missing.`,
@@ -398,13 +394,13 @@ export default class NFTDriverClient {
 	/**
 	 * Emits the user's metadata.
 	 * The key and the value are _not_ standardized by the protocol, it's up to the user to establish and follow conventions to ensure compatibility with the consumers.
-	 * @param  {BigNumberish} tokenId The ID of the token representing the collecting user ID. The token ID is equal to the user ID controlled by it.
+	 * @param  {string} tokenId The ID of the token representing the collecting user ID. The token ID is equal to the user ID controlled by it.
 	 * @param  {BigNumberish} key The metadata key.
 	 * @param  {BytesLike} value The metadata value.
 	 * @returns A `Promise` which resolves to the `ContractTransaction`.
 	 * @throws {DripsErrors.argumentMissingError} if any of the required parameters is missing.
 	 */
-	public emitUserMetadata(tokenId: BigNumberish, key: BigNumberish, value: BytesLike): Promise<ContractTransaction> {
+	public emitUserMetadata(tokenId: string, key: BigNumberish, value: BytesLike): Promise<ContractTransaction> {
 		if (isNullOrUndefined(tokenId)) {
 			throw DripsErrors.argumentMissingError(
 				`Could not set emit user metadata: '${nameOf({ tokenId })}' is missing.`,

--- a/tests/NFTDriver/NFTDriverClient.tests.ts
+++ b/tests/NFTDriver/NFTDriverClient.tests.ts
@@ -277,7 +277,7 @@ describe('NFTDriverClient', () => {
 
 		it('should return the expected token', async () => {
 			// Arrange
-			const expectedTokenId = 1n;
+			const expectedTokenId = '1';
 			const transferToAddress = Wallet.createRandom().address;
 
 			const waitFake = async () =>
@@ -338,7 +338,7 @@ describe('NFTDriverClient', () => {
 
 		it('should return the expected token', async () => {
 			// Arrange
-			const expectedTokenId = 1n;
+			const expectedTokenId = '1';
 			const transferToAddress = Wallet.createRandom().address;
 
 			const waitFake = async () =>
@@ -368,7 +368,7 @@ describe('NFTDriverClient', () => {
 
 			try {
 				// Act
-				await testNftDriverClient.collect(undefined as unknown as bigint, testAddress, testAddress);
+				await testNftDriverClient.collect(undefined as unknown as string, testAddress, testAddress);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -381,7 +381,7 @@ describe('NFTDriverClient', () => {
 
 		it('should validate the ERC20 and transferTo addresses', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 			const validateAddressStub = sinon.stub(internals, 'validateAddress');
@@ -402,7 +402,7 @@ describe('NFTDriverClient', () => {
 
 		it('should call the collect() method of the NFTDriver contract', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 
@@ -425,7 +425,7 @@ describe('NFTDriverClient', () => {
 
 			try {
 				// Act
-				await testNftDriverClient.give(undefined as unknown as bigint, '1', tokenAddress, 1);
+				await testNftDriverClient.give(undefined as unknown as string, '1', tokenAddress, 1);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -443,7 +443,7 @@ describe('NFTDriverClient', () => {
 
 			try {
 				// Act
-				await testNftDriverClient.give(1, undefined as unknown as string, tokenAddress, 1);
+				await testNftDriverClient.give('1', undefined as unknown as string, tokenAddress, 1);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -461,7 +461,7 @@ describe('NFTDriverClient', () => {
 
 			try {
 				// Act
-				await testNftDriverClient.give(1, ' 1', tokenAddress, -1);
+				await testNftDriverClient.give('1', ' 1', tokenAddress, -1);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
@@ -474,7 +474,7 @@ describe('NFTDriverClient', () => {
 
 		it('should validate the ERC20 address', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const validateAddressStub = sinon.stub(internals, 'validateAddress');
 
@@ -487,7 +487,7 @@ describe('NFTDriverClient', () => {
 
 		it('should call the give() method of the NFTDriver contract', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const amount = 100;
 			const receiverUserId = '1';
 			const tokenAddress = Wallet.createRandom().address;
@@ -512,14 +512,7 @@ describe('NFTDriverClient', () => {
 
 			try {
 				// Act
-				await testNftDriverClient.setDrips(
-					undefined as unknown as BigNumberish,
-					tokenAddress,
-					[],
-					[],
-					transferToAddress,
-					1
-				);
+				await testNftDriverClient.setDrips(undefined as unknown as string, tokenAddress, [], [], transferToAddress, 1);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -532,7 +525,7 @@ describe('NFTDriverClient', () => {
 
 		it('should validate the ERC20 address', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 			const currentReceivers: DripsReceiverStruct[] = [
@@ -567,7 +560,7 @@ describe('NFTDriverClient', () => {
 
 		it('should validate the drips receivers', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 
@@ -624,7 +617,7 @@ describe('NFTDriverClient', () => {
 			// Act
 			try {
 				await testNftDriverClient.setDrips(
-					1,
+					'1',
 					Wallet.createRandom().address,
 					[],
 					[],
@@ -643,7 +636,7 @@ describe('NFTDriverClient', () => {
 
 		it('should clear drips when new receivers is an empty list', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 			const currentReceivers: DripsReceiverStruct[] = [
@@ -672,7 +665,7 @@ describe('NFTDriverClient', () => {
 
 		it('should set balanceDelta to the default value of 0 when balanceDelta is not provided', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 
@@ -695,7 +688,7 @@ describe('NFTDriverClient', () => {
 
 		it('should call the setDrips() method of the NFTDriver contract', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
 			const currentReceivers: DripsReceiverStruct[] = [
@@ -751,7 +744,7 @@ describe('NFTDriverClient', () => {
 
 			// Act
 			try {
-				await testNftDriverClient.setSplits(undefined as unknown as BigNumberish, []);
+				await testNftDriverClient.setSplits(undefined as unknown as string, []);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -768,7 +761,7 @@ describe('NFTDriverClient', () => {
 
 			// Act
 			try {
-				await testNftDriverClient.setSplits(1, undefined as unknown as SplitsReceiverStruct[]);
+				await testNftDriverClient.setSplits('1', undefined as unknown as SplitsReceiverStruct[]);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -781,7 +774,7 @@ describe('NFTDriverClient', () => {
 
 		it('clears splits when new receivers is an empty list', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 
 			// Act
 			await testNftDriverClient.setSplits(tokenId, []);
@@ -795,7 +788,7 @@ describe('NFTDriverClient', () => {
 
 		it('should validate the splits receivers', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 
 			const receivers: SplitsReceiverStruct[] = [
 				{ userId: 1, weight: 1 },
@@ -813,7 +806,7 @@ describe('NFTDriverClient', () => {
 
 		it('should call the setSplits() method of the NFTDriver contract', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 
 			const receivers: SplitsReceiverStruct[] = [
 				{ userId: 2, weight: 100 },
@@ -845,7 +838,7 @@ describe('NFTDriverClient', () => {
 
 			// Act
 			try {
-				await testNftDriverClient.emitUserMetadata(undefined as unknown as BigNumberish, 'key', 'value');
+				await testNftDriverClient.emitUserMetadata(undefined as unknown as string, 'key', 'value');
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -862,7 +855,7 @@ describe('NFTDriverClient', () => {
 
 			// Act
 			try {
-				await testNftDriverClient.emitUserMetadata(1, undefined as unknown as BigNumberish, 'value');
+				await testNftDriverClient.emitUserMetadata('1', undefined as unknown as BigNumberish, 'value');
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -879,7 +872,7 @@ describe('NFTDriverClient', () => {
 
 			// Act
 			try {
-				await testNftDriverClient.emitUserMetadata(1, 'key', undefined as unknown as BytesLike);
+				await testNftDriverClient.emitUserMetadata('1', 'key', undefined as unknown as BytesLike);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
@@ -892,7 +885,7 @@ describe('NFTDriverClient', () => {
 
 		it('should call the emitUserMetadata() method of the NFTDriver contract', async () => {
 			// Arrange
-			const tokenId = 1;
+			const tokenId = '1';
 			const key = '1';
 			const value = 'value';
 


### PR DESCRIPTION
Change `tokenId` from `bigint` to `string` to be consistent with the other clients that also manage user IDs as `string`s.