### PR TITLE
Readonly Clients

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,9 @@
-node_modules
+contracts
+.nyc_output
+coverage
 dist
+node_modules
+docs
+address-driver-examples
+nft-driver-examples
+src/DripsSubgraph/generated

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,12 +4,12 @@
 		"es2021": true,
 		"mocha": true
 	},
-	"extends": ["airbnb-base", "prettier", "plugin:import/typescript"],
+	"extends": ["airbnb-base", "plugin:import/typescript", "prettier"],
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"ecmaVersion": "latest"
 	},
-	"plugins": ["@typescript-eslint", "prettier"],
+	"plugins": ["@typescript-eslint"],
 	"rules": {
 		"camelcase": "off",
 		"import/extensions": "off",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,9 @@
-
 contracts
 .nyc_output
 coverage
 dist
 node_modules
+docs
+address-driver-examples
+nft-driver-examples
+src/DripsSubgraph/generated

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
-  "semi": true,
-  "printWidth": 120,
-  "singleQuote": true,
-  "bracketSpacing": true,
-  "trailingComma": "none"
+	"semi": true,
+	"printWidth": 120,
+	"singleQuote": true,
+	"bracketSpacing": true,
+	"trailingComma": "none"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.23.0",
 				"@typescript-eslint/parser": "^5.23.0",
 				"chai": "^4.3.6",
+				"cz-conventional-changelog": "^3.3.0",
 				"eslint": "^8.17.0",
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-config-prettier": "^8.5.0",
@@ -1142,6 +1143,116 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@commitlint/config-validator": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.1.0.tgz",
+			"integrity": "sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@commitlint/types": "^17.0.0",
+				"ajv": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=v14"
+			}
+		},
+		"node_modules/@commitlint/config-validator/node_modules/ajv": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+			"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"optional": true
+		},
+		"node_modules/@commitlint/execute-rule": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
+			"integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=v14"
+			}
+		},
+		"node_modules/@commitlint/load": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
+			"integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@commitlint/config-validator": "^17.1.0",
+				"@commitlint/execute-rule": "^17.0.0",
+				"@commitlint/resolve-extends": "^17.1.0",
+				"@commitlint/types": "^17.0.0",
+				"@types/node": "^14.0.0",
+				"chalk": "^4.1.0",
+				"cosmiconfig": "^7.0.0",
+				"cosmiconfig-typescript-loader": "^4.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"ts-node": "^10.8.1",
+				"typescript": "^4.6.4"
+			},
+			"engines": {
+				"node": ">=v14"
+			}
+		},
+		"node_modules/@commitlint/load/node_modules/@types/node": {
+			"version": "14.18.33",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+			"integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
+			"dev": true,
+			"optional": true
+		},
+		"node_modules/@commitlint/resolve-extends": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
+			"integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"@commitlint/config-validator": "^17.1.0",
+				"@commitlint/types": "^17.0.0",
+				"import-fresh": "^3.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"resolve-global": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=v14"
+			}
+		},
+		"node_modules/@commitlint/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"chalk": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=v14"
+			}
+		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1182,18 +1293,6 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@ethereumjs/common": {
@@ -4246,6 +4345,15 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
+		"node_modules/at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/auto-bind": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
@@ -4803,6 +4911,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/cachedir": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/caching-transform": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -5323,6 +5440,118 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/commitizen": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.5.tgz",
+			"integrity": "sha512-9sXju8Qrz1B4Tw7kC5KhnvwYQN88qs2zbiB8oyMsnXZyJ24PPGiNM3nHr73d32dnE3i8VJEXddBFIbOgYSEXtQ==",
+			"dev": true,
+			"dependencies": {
+				"cachedir": "2.3.0",
+				"cz-conventional-changelog": "3.3.0",
+				"dedent": "0.7.0",
+				"detect-indent": "6.1.0",
+				"find-node-modules": "^2.1.2",
+				"find-root": "1.1.0",
+				"fs-extra": "9.1.0",
+				"glob": "7.2.3",
+				"inquirer": "8.2.4",
+				"is-utf8": "^0.2.1",
+				"lodash": "4.17.21",
+				"minimist": "1.2.6",
+				"strip-bom": "4.0.0",
+				"strip-json-comments": "3.1.1"
+			},
+			"bin": {
+				"commitizen": "bin/commitizen",
+				"cz": "bin/git-cz",
+				"git-cz": "bin/git-cz"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/commitizen/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/commitizen/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/commitizen/node_modules/inquirer": {
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+			"integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.1.1",
+				"cli-cursor": "^3.1.0",
+				"cli-width": "^3.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.21",
+				"mute-stream": "0.0.8",
+				"ora": "^5.4.1",
+				"run-async": "^2.4.0",
+				"rxjs": "^7.5.5",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"through": "^2.3.6",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/commitizen/node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/commitizen/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/common-tags": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -5418,6 +5647,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/conventional-commit-types": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
+			"integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
+			"dev": true
 		},
 		"node_modules/convert-source-map": {
 			"version": "1.8.0",
@@ -5603,6 +5838,88 @@
 				"node": "*"
 			}
 		},
+		"node_modules/cz-conventional-changelog": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+			"integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.4.1",
+				"commitizen": "^4.0.3",
+				"conventional-commit-types": "^3.0.0",
+				"lodash.map": "^4.5.1",
+				"longest": "^2.0.1",
+				"word-wrap": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@commitlint/load": ">6.1.1"
+			}
+		},
+		"node_modules/cz-conventional-changelog/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/cz-conventional-changelog/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/cz-conventional-changelog/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/cz-conventional-changelog/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/cz-conventional-changelog/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/cz-conventional-changelog/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/d": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -5698,6 +6015,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+			"dev": true
 		},
 		"node_modules/deep-eql": {
 			"version": "3.0.1",
@@ -5820,6 +6143,15 @@
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/detect-file": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+			"integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/detect-indent": {
@@ -6854,18 +7186,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/eslint/node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/espree": {
 			"version": "9.3.2",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
@@ -7216,6 +7536,18 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
+		"node_modules/expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"dev": true,
+			"dependencies": {
+				"homedir-polyfill": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/express": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -7523,6 +7855,16 @@
 				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
 			}
 		},
+		"node_modules/find-node-modules": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
+			"integrity": "sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==",
+			"dev": true,
+			"dependencies": {
+				"findup-sync": "^4.0.0",
+				"merge": "^2.1.1"
+			}
+		},
 		"node_modules/find-replace": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -7534,6 +7876,12 @@
 			"engines": {
 				"node": ">=4.0.0"
 			}
+		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
@@ -7549,6 +7897,21 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/findup-sync": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+			"integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+			"dev": true,
+			"dependencies": {
+				"detect-file": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"micromatch": "^4.0.2",
+				"resolve-dir": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/flat": {
@@ -7899,6 +8262,61 @@
 			"dependencies": {
 				"min-document": "^2.19.0",
 				"process": "^0.11.10"
+			}
+		},
+		"node_modules/global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"ini": "^1.3.4"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"dev": true,
+			"dependencies": {
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+			"dev": true,
+			"dependencies": {
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/global-prefix/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
 			}
 		},
 		"node_modules/globals": {
@@ -8294,6 +8712,18 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
+		"node_modules/homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
+			"dependencies": {
+				"parse-passwd": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8538,6 +8968,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"node_modules/inquirer": {
@@ -8986,6 +9422,12 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+			"dev": true
+		},
+		"node_modules/is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
 			"dev": true
 		},
 		"node_modules/is-weakref": {
@@ -9546,6 +9988,12 @@
 			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true
 		},
+		"node_modules/lodash.map": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+			"integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9621,6 +10069,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/longest": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
+			"integrity": "sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/loose-envify": {
@@ -9774,6 +10231,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/merge": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+			"integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+			"dev": true
 		},
 		"node_modules/merge-descriptors": {
 			"version": "1.0.1",
@@ -10099,18 +10562,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/mocha/node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/mocha/node_modules/supports-color": {
 			"version": "8.1.1",
@@ -10980,6 +11431,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -11660,6 +12120,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -11689,11 +12159,37 @@
 			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
 			"dev": true
 		},
+		"node_modules/resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+			"dev": true,
+			"dependencies": {
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-global": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+			"integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"global-dirs": "^0.1.1"
+			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -12445,6 +12941,18 @@
 			"engines": {
 				"node": ">=6.5.0",
 				"npm": ">=3"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/sucrase": {
@@ -15823,6 +16331,101 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@commitlint/config-validator": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.1.0.tgz",
+			"integrity": "sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@commitlint/types": "^17.0.0",
+				"ajv": "^8.11.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.11.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"@commitlint/execute-rule": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
+			"integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@commitlint/load": {
+			"version": "17.2.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
+			"integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@commitlint/config-validator": "^17.1.0",
+				"@commitlint/execute-rule": "^17.0.0",
+				"@commitlint/resolve-extends": "^17.1.0",
+				"@commitlint/types": "^17.0.0",
+				"@types/node": "^14.0.0",
+				"chalk": "^4.1.0",
+				"cosmiconfig": "^7.0.0",
+				"cosmiconfig-typescript-loader": "^4.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"ts-node": "^10.8.1",
+				"typescript": "^4.6.4"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "14.18.33",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+					"integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"@commitlint/resolve-extends": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
+			"integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@commitlint/config-validator": "^17.1.0",
+				"@commitlint/types": "^17.0.0",
+				"import-fresh": "^3.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"resolve-global": "^1.0.0"
+			}
+		},
+		"@commitlint/types": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
+			"integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"chalk": "^4.1.0"
+			}
+		},
 		"@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -15859,14 +16462,6 @@
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-					"dev": true
-				}
 			}
 		},
 		"@ethereumjs/common": {
@@ -18130,6 +18725,12 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true
+		},
 		"auto-bind": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
@@ -18572,6 +19173,12 @@
 				}
 			}
 		},
+		"cachedir": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+			"dev": true
+		},
 		"caching-transform": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -18988,6 +19595,95 @@
 			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
 			"dev": true
 		},
+		"commitizen": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.5.tgz",
+			"integrity": "sha512-9sXju8Qrz1B4Tw7kC5KhnvwYQN88qs2zbiB8oyMsnXZyJ24PPGiNM3nHr73d32dnE3i8VJEXddBFIbOgYSEXtQ==",
+			"dev": true,
+			"requires": {
+				"cachedir": "2.3.0",
+				"cz-conventional-changelog": "3.3.0",
+				"dedent": "0.7.0",
+				"detect-indent": "6.1.0",
+				"find-node-modules": "^2.1.2",
+				"find-root": "1.1.0",
+				"fs-extra": "9.1.0",
+				"glob": "7.2.3",
+				"inquirer": "8.2.4",
+				"is-utf8": "^0.2.1",
+				"lodash": "4.17.21",
+				"minimist": "1.2.6",
+				"strip-bom": "4.0.0",
+				"strip-json-comments": "3.1.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.2.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.1.1",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"inquirer": {
+					"version": "8.2.4",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+					"integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.1.1",
+						"cli-cursor": "^3.1.0",
+						"cli-width": "^3.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^3.0.0",
+						"lodash": "^4.17.21",
+						"mute-stream": "0.0.8",
+						"ora": "^5.4.1",
+						"run-async": "^2.4.0",
+						"rxjs": "^7.5.5",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0",
+						"through": "^2.3.6",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
+			}
+		},
 		"common-tags": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -19063,6 +19759,12 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
+		"conventional-commit-types": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
+			"integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
 			"dev": true
 		},
 		"convert-source-map": {
@@ -19219,6 +19921,73 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"cz-conventional-changelog": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+			"integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
+			"dev": true,
+			"requires": {
+				"@commitlint/load": ">6.1.1",
+				"chalk": "^2.4.1",
+				"commitizen": "^4.0.3",
+				"conventional-commit-types": "^3.0.0",
+				"lodash.map": "^4.5.1",
+				"longest": "^2.0.1",
+				"word-wrap": "^1.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"d": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -19287,6 +20056,12 @@
 					"dev": true
 				}
 			}
+		},
+		"dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+			"dev": true
 		},
 		"deep-eql": {
 			"version": "3.0.1",
@@ -19375,6 +20150,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
 			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"dev": true
+		},
+		"detect-file": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+			"integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
 			"dev": true
 		},
 		"detect-indent": {
@@ -19884,12 +20665,6 @@
 					"requires": {
 						"is-glob": "^4.0.3"
 					}
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-					"dev": true
 				}
 			}
 		},
@@ -20397,6 +21172,15 @@
 				"strip-final-newline": "^2.0.0"
 			}
 		},
+		"expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "^1.0.1"
+			}
+		},
 		"express": {
 			"version": "4.18.2",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -20657,6 +21441,16 @@
 				"pkg-dir": "^4.1.0"
 			}
 		},
+		"find-node-modules": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.3.tgz",
+			"integrity": "sha512-UC2I2+nx1ZuOBclWVNdcnbDR5dlrOdVb7xNjmT/lHE+LsgztWks3dG7boJ37yTS/venXw84B/mAW9uHVoC5QRg==",
+			"dev": true,
+			"requires": {
+				"findup-sync": "^4.0.0",
+				"merge": "^2.1.1"
+			}
+		},
 		"find-replace": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -20666,6 +21460,12 @@
 				"array-back": "^3.0.1"
 			}
 		},
+		"find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true
+		},
 		"find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -20674,6 +21474,18 @@
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
+			}
+		},
+		"findup-sync": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+			"integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+			"dev": true,
+			"requires": {
+				"detect-file": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"micromatch": "^4.0.2",
+				"resolve-dir": "^1.0.1"
 			}
 		},
 		"flat": {
@@ -20930,6 +21742,51 @@
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "^0.11.10"
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"ini": "^1.3.4"
+			}
+		},
+		"global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"dev": true,
+			"requires": {
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
+			}
+		},
+		"global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"globals": {
@@ -21224,6 +22081,15 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
+		"homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
+			"requires": {
+				"parse-passwd": "^1.0.0"
+			}
+		},
 		"html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -21403,6 +22269,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"inquirer": {
@@ -21726,6 +22598,12 @@
 					"dev": true
 				}
 			}
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+			"dev": true
 		},
 		"is-weakref": {
 			"version": "1.0.2",
@@ -22189,6 +23067,12 @@
 			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"dev": true
 		},
+		"lodash.map": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+			"integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==",
+			"dev": true
+		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -22246,6 +23130,12 @@
 					}
 				}
 			}
+		},
+		"longest": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
+			"integrity": "sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -22370,6 +23260,12 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"dev": true
+		},
+		"merge": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+			"integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
 			"dev": true
 		},
 		"merge-descriptors": {
@@ -22619,12 +23515,6 @@
 					"version": "2.1.3",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-					"dev": true
-				},
-				"strip-json-comments": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 					"dev": true
 				},
 				"supports-color": {
@@ -23304,6 +24194,12 @@
 				"lines-and-columns": "^1.1.6"
 			}
 		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+			"dev": true
+		},
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -23819,6 +24715,13 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"optional": true
+		},
 		"require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -23842,11 +24745,31 @@
 			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
 			"dev": true
 		},
+		"resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
+			}
+		},
 		"resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"dev": true
+		},
+		"resolve-global": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+			"integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"global-dirs": "^0.1.1"
+			}
 		},
 		"responselike": {
 			"version": "2.0.1",
@@ -24450,6 +25373,12 @@
 			"requires": {
 				"is-hex-prefixed": "1.0.0"
 			}
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
 		},
 		"sucrase": {
 			"version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,20 @@
 	"files": [
 		"dist/"
 	],
+	"tsup": {
+		"clean": true,
+		"format": [
+			"cjs",
+			"esm"
+		],
+		"bundle": true,
+		"entry": [
+			"./src/index.ts"
+		]
+	},
 	"scripts": {
-		"lint": "eslint . --ext .ts",
-		"lint-and-fix": "eslint . --ext .ts --fix",
+		"lint": "prettier . --check . && eslint .",
+		"format": "prettier . --write .",
 		"build": "npm run generate-graphql-types && npm run build:contracts && npm run build:lib && npx typedoc --excludeInternal src/index.ts",
 		"build:lib": "tsup --dts",
 		"build:contracts": "typechain --target=ethers-v5 --out-dir contracts ./src/abi/**.json",
@@ -42,6 +53,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.23.0",
 		"@typescript-eslint/parser": "^5.23.0",
 		"chai": "^4.3.6",
+		"cz-conventional-changelog": "^3.3.0",
 		"eslint": "^8.17.0",
 		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-config-prettier": "^8.5.0",
@@ -64,5 +76,10 @@
 	},
 	"peerDependencies": {
 		"ethers": "^5.6.2"
+	},
+	"config": {
+		"commitizen": {
+			"path": "./node_modules/cz-conventional-changelog"
+		}
 	}
 }

--- a/src/DripsHub/DripsHubClient.ts
+++ b/src/DripsHub/DripsHubClient.ts
@@ -94,6 +94,9 @@ export default class DripsHubClient {
 	 * Creates a new immutable `DripsHubClient` instance that allows only **read-only operations** (i.e., any operation that does _not_ require signing).
 	 * @param  {JsonRpcProvider} provider The network provider.
 	 *
+	 * Note that even if the `provider` has a `singer` associated with it, the client will ignore it.
+	 * If you want to _sign_ transactions use the {@link create} method instead.
+	 *
 	 * Supported networks are:
 	 * - 'goerli': chain ID `5`
 	 * @param  {string|undefined} customDriverAddress Overrides the `DripsHub`'s address.

--- a/src/common/DripsError.ts
+++ b/src/common/DripsError.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 
 export enum DripsErrorCode {
+	MISSING_SIGNER = 'MISSING_SIGNER',
 	INVALID_ADDRESS = 'INVALID_ADDRESS',
 	INVALID_ARGUMENT = 'INVALID_ARGUMENT',
 	MISSING_ARGUMENT = 'MISSING_ARGUMENT',
@@ -28,6 +29,10 @@ export class DripsErrors {
 		new DripsError(DripsErrorCode.INVALID_ADDRESS, message, {
 			invalidAddress: address
 		});
+
+	static signerMissingError = (
+		message: string = "Tried to perform an operation that requires a signer, but the client's provider does not have a signer associated with it."
+	) => new DripsError(DripsErrorCode.MISSING_SIGNER, message);
 
 	static argumentMissingError = (message: string, argName: string) =>
 		new DripsError(DripsErrorCode.MISSING_ARGUMENT, message, {

--- a/src/common/DripsError.ts
+++ b/src/common/DripsError.ts
@@ -31,7 +31,7 @@ export class DripsErrors {
 		});
 
 	static signerMissingError = (
-		message: string = "Tried to perform an operation that requires a signer, but the client's provider does not have a signer associated with it."
+		message: string = 'Tried to perform an operation that requires a signer, but a signer was not found. Did you create a read-only client instance?'
 	) => new DripsError(DripsErrorCode.MISSING_SIGNER, message);
 
 	static argumentMissingError = (message: string, argName: string) =>

--- a/src/common/internals.ts
+++ b/src/common/internals.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 
-import type { JsonRpcProvider } from '@ethersproject/providers';
+import type { JsonRpcSigner } from '@ethersproject/providers';
 import { BigNumber } from 'ethers';
 import { DripsErrors } from './DripsError';
 import type { DripsReceiverStruct, SplitsReceiverStruct } from './types';
@@ -67,8 +67,8 @@ export const formatSplitReceivers = (receivers: SplitsReceiverStruct[]): SplitsR
 };
 
 /** @internal */
-export const ensureSignerExists = (provider: JsonRpcProvider) => {
-	if (isNullOrUndefined(provider.getSigner())) {
+export function ensureSignerExists(signer: JsonRpcSigner | undefined): asserts signer is NonNullable<JsonRpcSigner> {
+	if (isNullOrUndefined(signer)) {
 		throw DripsErrors.signerMissingError();
 	}
-};
+}

--- a/src/common/internals.ts
+++ b/src/common/internals.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-nested-ternary */
 
+import type { JsonRpcProvider } from '@ethersproject/providers';
 import { BigNumber } from 'ethers';
+import { DripsErrors } from './DripsError';
 import type { DripsReceiverStruct, SplitsReceiverStruct } from './types';
 
 /** @internal */
@@ -62,4 +64,11 @@ export const formatSplitReceivers = (receivers: SplitsReceiverStruct[]): SplitsR
 	);
 
 	return sortedReceivers;
+};
+
+/** @internal */
+export const ensureSignerExists = (provider: JsonRpcProvider) => {
+	if (isNullOrUndefined(provider.getSigner())) {
+		throw DripsErrors.signerMissingError();
+	}
 };

--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -154,18 +154,6 @@ export const validateClientProvider = async (provider: JsonRpcProvider, supporte
 		throw DripsErrors.argumentMissingError(`'${nameOf({ provider })}' is missing.`, nameOf({ provider }));
 	}
 
-	const signer = provider.getSigner();
-	const signerAddress = await signer?.getAddress();
-	if (!signerAddress) {
-		throw DripsErrors.argumentError(
-			`'${nameOf({ signerAddress })}' is missing.`,
-			nameOf({ signerAddress }),
-			signerAddress
-		);
-	}
-
-	validateAddress(signerAddress);
-
 	const network = await provider.getNetwork();
 	if (!supportedChains.includes(network?.chainId)) {
 		throw DripsErrors.unsupportedNetworkError(

--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -1,4 +1,4 @@
-import type { JsonRpcProvider } from '@ethersproject/providers';
+import type { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 import type { BigNumberish } from 'ethers';
 import { ethers } from 'ethers';
 import { DripsErrors } from './DripsError';
@@ -161,6 +161,17 @@ export const validateClientProvider = async (provider: JsonRpcProvider, supporte
 			network?.chainId
 		);
 	}
+};
+
+/** @internal */
+export const validateClientSigner = async (signer: JsonRpcSigner, supportedChains: readonly number[]) => {
+	if (!signer) {
+		throw DripsErrors.argumentMissingError(`'${nameOf({ signer })}' is missing.`, nameOf({ signer }));
+	}
+
+	const { provider } = signer;
+
+	await validateClientProvider(provider, supportedChains);
 };
 
 /** @internal */

--- a/tests/AddressDriver/AddressDriverClient.tests.ts
+++ b/tests/AddressDriver/AddressDriverClient.tests.ts
@@ -13,7 +13,6 @@ import Utils from '../../src/utils';
 import { DripsErrorCode } from '../../src/common/DripsError';
 import * as validators from '../../src/common/validators';
 import DripsHubClient from '../../src/DripsHub/DripsHubClient';
-import CallerClient from '../../src/Caller/CallerClient';
 import * as internals from '../../src/common/internals';
 
 describe('AddressDriverClient', () => {
@@ -22,7 +21,6 @@ describe('AddressDriverClient', () => {
 	let networkStub: StubbedInstance<Network>;
 	let signerStub: StubbedInstance<JsonRpcSigner>;
 	let providerStub: StubbedInstance<JsonRpcProvider>;
-	let callerClientStub: StubbedInstance<CallerClient>;
 	let dripsHubClientStub: StubbedInstance<DripsHubClient>;
 	let addressDriverContractStub: StubbedInstance<AddressDriver>;
 	let addressDriverInterfaceStub: StubbedInstance<AddressDriverInterface>;
@@ -57,9 +55,6 @@ describe('AddressDriverClient', () => {
 
 		dripsHubClientStub = stubInterface<DripsHubClient>();
 		sinon.stub(DripsHubClient, 'create').resolves(dripsHubClientStub);
-
-		callerClientStub = stubInterface<CallerClient>();
-		sinon.stub(CallerClient, 'create').resolves(callerClientStub);
 
 		testAddressDriverClient = await AddressDriverClient.create(signerStub);
 	});

--- a/tests/AddressDriver/AddressDriverClient.tests.ts
+++ b/tests/AddressDriver/AddressDriverClient.tests.ts
@@ -13,6 +13,7 @@ import { DripsErrorCode } from '../../src/common/DripsError';
 import * as validators from '../../src/common/validators';
 import DripsHubClient from '../../src/DripsHub/DripsHubClient';
 import CallerClient from '../../src/Caller/CallerClient';
+import * as internals from '../../src/common/internals';
 
 describe('AddressDriverClient', () => {
 	const TEST_CHAIN_ID = 5; // Goerli.
@@ -103,6 +104,32 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('getAllowance()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const tokenAddress = Wallet.createRandom().address;
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			const erc20ContractStub = stubInterface<IERC20>();
+
+			erc20ContractStub.allowance
+				.withArgs(await signerStub.getAddress(), testAddressDriverClient.driverAddress)
+				.resolves(BigNumber.from(1));
+
+			sinon
+				.stub(IERC20__factory, 'connect')
+				.withArgs(tokenAddress, testAddressDriverClient.provider.getSigner())
+				.returns(erc20ContractStub);
+
+			// Act
+			await testAddressDriverClient.getAllowance(tokenAddress);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const tokenAddress = Wallet.createRandom().address;
@@ -157,6 +184,28 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('approve()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const tokenAddress = Wallet.createRandom().address;
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			const erc20ContractStub = stubInterface<IERC20>();
+
+			sinon
+				.stub(IERC20__factory, 'connect')
+				.withArgs(tokenAddress, testAddressDriverClient.provider.getSigner())
+				.returns(erc20ContractStub);
+
+			// Act
+			await testAddressDriverClient.approve(tokenAddress);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should validate the ERC20 address', async () => {
 			// Arrange
 			const tokenAddress = 'invalid address';
@@ -199,6 +248,24 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('getUserId()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			addressDriverContractStub.calcUserId
+				.withArgs(await testAddressDriverClient.provider.getSigner().getAddress())
+				.resolves(BigNumber.from(111));
+
+			// Act
+			await testAddressDriverClient.getUserId();
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should call the calcUserId() method of the AddressDriver contract', async () => {
 			// Arrange
 			addressDriverContractStub.calcUserId
@@ -249,7 +316,24 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('collect()', () => {
-		it('should the input', async () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			const tokenAddress = Wallet.createRandom().address;
+			const transferToAddress = Wallet.createRandom().address;
+
+			// Act
+			await testAddressDriverClient.collect(tokenAddress, transferToAddress);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
+		it('should validate the input', async () => {
 			// Arrange
 			const tokenAddress = Wallet.createRandom().address;
 			const transferToAddress = Wallet.createRandom().address;
@@ -282,6 +366,21 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('give()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+			const tokenAddress = Wallet.createRandom().address;
+
+			// Act
+			await testAddressDriverClient.give('1', tokenAddress, 1n);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should throw argumentMissingError when receiverUserId is missing', async () => {
 			// Arrange
 			let threw = false;
@@ -348,6 +447,20 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('setSplits()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			// Act
+			await testAddressDriverClient.setSplits([]);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should throw argumentMissingError when splits receivers are missing', async () => {
 			// Arrange
 			let threw = false;
@@ -417,6 +530,22 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('setDrips()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const tokenAddress = Wallet.createRandom().address;
+			const transferToAddress = Wallet.createRandom().address;
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			// Act
+			await testAddressDriverClient.setDrips(tokenAddress, [], [], transferToAddress, undefined as unknown as bigint);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should validate the input', async () => {
 			// Arrange
 			const tokenAddress = Wallet.createRandom().address;
@@ -572,6 +701,24 @@ describe('AddressDriverClient', () => {
 	});
 
 	describe('emitUserMetadata()', () => {
+		it('should ensure the signer exists', async () => {
+			// Arrange
+			const key = '1';
+			const value = 'value';
+
+			// Act
+			const ensureSignerExistsStub = sinon.stub(internals, 'ensureSignerExists');
+
+			// Act
+			await testAddressDriverClient.emitUserMetadata(key, value);
+
+			// Assert
+			assert(
+				ensureSignerExistsStub.calledOnceWithExactly(testAddressDriverClient.provider),
+				'Expected method to be called with different arguments'
+			);
+		});
+
 		it('should validate the input', async () => {
 			// Arrange
 			const expectedKey = '1';

--- a/tests/common/DripsError.tests.ts
+++ b/tests/common/DripsError.tests.ts
@@ -31,6 +31,20 @@ describe('DripsErrors', () => {
 		});
 	});
 
+	describe('signerMissingError()', () => {
+		it('should return expected error details', () => {
+			// Arrange
+			const expectedMessage = 'Error';
+
+			// Act
+			const { code, message } = DripsErrors.signerMissingError(expectedMessage);
+
+			// Assert
+			assert.equal(message, expectedMessage);
+			assert.equal(code, DripsErrorCode.MISSING_SIGNER);
+		});
+	});
+
 	describe('argumentMissingError()', () => {
 		it('should return expected error details', () => {
 			// Arrange

--- a/tests/common/internals.tests.ts
+++ b/tests/common/internals.tests.ts
@@ -1,12 +1,33 @@
 import { assert } from 'chai';
 import sinon from 'ts-sinon';
+import type { JsonRpcProvider } from '@ethersproject/providers';
 import * as internals from '../../src/common/internals';
 import Utils from '../../src/utils';
 import type { DripsReceiverStruct, SplitsReceiverStruct } from '../../src/common/types';
+import { DripsErrorCode } from '../../src/common/DripsError';
 
 describe('internals', () => {
 	afterEach(() => {
 		sinon.restore();
+	});
+
+	describe('ensureSignerExists()', () => {
+		it("throw a signerMissingError when the provider's signer is missing", () => {
+			// Arrange
+			let threw = false;
+
+			try {
+				// Act
+				internals.ensureSignerExists({ getSigner: () => undefined } as unknown as JsonRpcProvider);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_SIGNER);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
 	});
 
 	describe('nameOf()', () => {

--- a/tests/common/internals.tests.ts
+++ b/tests/common/internals.tests.ts
@@ -1,6 +1,5 @@
 import { assert } from 'chai';
 import sinon from 'ts-sinon';
-import type { JsonRpcProvider } from '@ethersproject/providers';
 import * as internals from '../../src/common/internals';
 import Utils from '../../src/utils';
 import type { DripsReceiverStruct, SplitsReceiverStruct } from '../../src/common/types';
@@ -12,13 +11,13 @@ describe('internals', () => {
 	});
 
 	describe('ensureSignerExists()', () => {
-		it("throw a signerMissingError when the provider's signer is missing", () => {
+		it('throw a signerMissingError when the signer is missing', () => {
 			// Arrange
 			let threw = false;
 
 			try {
 				// Act
-				internals.ensureSignerExists({ getSigner: () => undefined } as unknown as JsonRpcProvider);
+				internals.ensureSignerExists(undefined);
 			} catch (error: any) {
 				// Assert
 				assert.equal(error.code, DripsErrorCode.MISSING_SIGNER);

--- a/tests/common/validators.tests.ts
+++ b/tests/common/validators.tests.ts
@@ -708,4 +708,38 @@ describe('validators', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 	});
+
+	describe('validateClientSigner', () => {
+		it('should throw the expected error when the signer is missing', async () => {
+			// Arrange
+			let threw = false;
+
+			try {
+				// Act
+				await validators.validateClientSigner(undefined as unknown as JsonRpcSigner, []);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.MISSING_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
+		it('should validate provider', () => {
+			// Arrange
+			const signer = { provider: {} as unknown as JsonRpcProvider } as unknown as JsonRpcSigner;
+			const validateClientProviderStub = sinon.stub(validators, 'validateClientProvider');
+
+			// Act
+			validators.validateClientSigner(signer, []);
+
+			// Assert
+			assert(
+				validateClientProviderStub.calledWithExactly(signer.provider, []),
+				'Expected method to be called with different arguments'
+			);
+		});
+	});
 });

--- a/tests/common/validators.tests.ts
+++ b/tests/common/validators.tests.ts
@@ -685,46 +685,6 @@ describe('validators', () => {
 			assert.isTrue(threw, 'Expected type of exception was not thrown');
 		});
 
-		it("should throw the expected error when the provider's signer is missing", async () => {
-			// Arrange
-			let threw = false;
-			const providerStub = sinon.createStubInstance(JsonRpcProvider);
-
-			providerStub.getSigner.returns(undefined as unknown as JsonRpcSigner);
-
-			try {
-				// Act
-				await validators.validateClientProvider(providerStub, []);
-			} catch (error: any) {
-				// Assert
-				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
-				threw = true;
-			}
-
-			// Assert
-			assert.isTrue(threw, 'Expected type of exception was not thrown');
-		});
-
-		it("should validate the provider's signer address", async () => {
-			// Arrange
-			const validateAddressStub = sinon.stub(validators, 'validateAddress');
-			const providerStub = sinon.createStubInstance(JsonRpcProvider);
-			const signerStub = sinon.createStubInstance(JsonRpcSigner);
-			signerStub.getAddress.resolves(Wallet.createRandom().address);
-			const networkStub = stubObject<Network>({ chainId: 5 } as Network);
-			providerStub.getSigner.returns(signerStub);
-			providerStub.getNetwork.resolves(networkStub);
-
-			// Act
-			await validators.validateClientProvider(providerStub, [5]);
-
-			// Assert
-			assert(
-				validateAddressStub.calledOnceWithExactly(await signerStub.getAddress()),
-				'Expected method to be called with different arguments'
-			);
-		});
-
 		it('should throw unsupportedNetworkError error when the provider is connected to an unsupported network', async () => {
 			// Arrange
 			let threw = false;

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,8 +1,0 @@
-import { defineConfig } from 'tsup'
-
-export default defineConfig({
-  clean: true,
-  format: ['cjs', 'esm'],
-  bundle: true,
-  entry: ['./src/index.ts']
-})


### PR DESCRIPTION
Allows the creation of read-only `AddressDriverClient` and `DripsHubClient` instances by exposing two static factory methods:

- create(provider) => for read-only operations
- createReadonly(signer) => for state-changing (and read-only) operations

Note that even if the `create(provider)` is used to create a new instance and the `provider` has a `signer` associated with it, it will be ignored. The API should guide the users two use either one of those methods depending on the use case.

The `NFTDriverClient`, 'ImmutableSplits`, and `CallerClient` only expose "write" operations and there is no need to have read-only instances.

(Plus some minor linting configuration changes)