### PR TITLE
Metadata examples

### DIFF
--- a/address-driver-examples/package-lock.json
+++ b/address-driver-examples/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@walletconnect/web3-provider": "^1.8.0",
 				"ethers": "^5.7.2",
-				"radicle-drips": "github:radicle-dev/drips-js-sdk",
+				"radicle-drips": "github:radicle-dev/drips-js-sdk#metadata-examples",
 				"svelte-json-tree": "^1.0.0",
 				"web3modal": "^1.9.9"
 			},
@@ -5528,7 +5528,7 @@
 		},
 		"node_modules/radicle-drips": {
 			"version": "2.0.0",
-			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#1fd9936c07344980a10a7427a80f63f117d44a1e",
+			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#261df8931373f61faf0ad1b947e08fc05a819645",
 			"peerDependencies": {
 				"ethers": "^5.6.2"
 			}
@@ -11027,8 +11027,8 @@
 			"dev": true
 		},
 		"radicle-drips": {
-			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#1fd9936c07344980a10a7427a80f63f117d44a1e",
-			"from": "radicle-drips@radicle-dev/drips-js-sdk",
+			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#261df8931373f61faf0ad1b947e08fc05a819645",
+			"from": "radicle-drips@radicle-dev/drips-js-sdk#metadata-examples",
 			"requires": {}
 		},
 		"randombytes": {

--- a/address-driver-examples/package.json
+++ b/address-driver-examples/package.json
@@ -35,7 +35,7 @@
 	"dependencies": {
 		"@walletconnect/web3-provider": "^1.8.0",
 		"ethers": "^5.7.2",
-		"radicle-drips": "github:radicle-dev/drips-js-sdk",
+		"radicle-drips": "github:radicle-dev/drips-js-sdk#metadata-examples",
 		"svelte-json-tree": "^1.0.0",
 		"web3modal": "^1.9.9"
 	}

--- a/address-driver-examples/src/routes/+page.svelte
+++ b/address-driver-examples/src/routes/+page.svelte
@@ -42,15 +42,25 @@
 				</ul>
 			</li>
 			<li>
+				Metadata:
+				<ul>
+					<li>Emit User Metadata*</li>
+				</ul>
+			</li>
+			<li />
+			<li>
 				Utilities:
 				<ul>
 					<li><a href="/utils">Asset Helpers</a></li>
 					<li><a href="/utils">Cycle info</a></li>
 					<li><a href="/utils">Debug Drips Receiver Configuration</a></li>
 					<li><a href="/utils">User IDs</a></li>
+					<li>Debug User Metadata*</li>
 				</ul>
 			</li>
 		</ul>
+
+		<p>* Check the <code>NFTDriverClient</code> examples app.</p>
 	{:else}
 		<h2>Connect to start</h2>
 	{/if}
@@ -70,5 +80,9 @@
 
 	.btn-group {
 		padding: var(--global-line-height);
+	}
+
+	p {
+		font-size: 80%;
 	}
 </style>

--- a/nft-driver-examples/package-lock.json
+++ b/nft-driver-examples/package-lock.json
@@ -5528,7 +5528,7 @@
 		},
 		"node_modules/radicle-drips": {
 			"version": "2.0.0",
-			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8c3aef8700a63e00311efcbdf9436896cbcf50fb",
+			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#2493da0755f320b4e1cc4e0cd0a9bbe775338913",
 			"peerDependencies": {
 				"ethers": "^5.6.2"
 			}
@@ -11027,7 +11027,7 @@
 			"dev": true
 		},
 		"radicle-drips": {
-			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8c3aef8700a63e00311efcbdf9436896cbcf50fb",
+			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#2493da0755f320b4e1cc4e0cd0a9bbe775338913",
 			"from": "radicle-drips@radicle-dev/drips-js-sdk#metadata-examples",
 			"requires": {}
 		},

--- a/nft-driver-examples/package-lock.json
+++ b/nft-driver-examples/package-lock.json
@@ -5528,7 +5528,7 @@
 		},
 		"node_modules/radicle-drips": {
 			"version": "2.0.0",
-			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#96438515f870138ad3e686f58e1a032df49e9250",
+			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8c3aef8700a63e00311efcbdf9436896cbcf50fb",
 			"peerDependencies": {
 				"ethers": "^5.6.2"
 			}
@@ -11027,7 +11027,7 @@
 			"dev": true
 		},
 		"radicle-drips": {
-			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#96438515f870138ad3e686f58e1a032df49e9250",
+			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#8c3aef8700a63e00311efcbdf9436896cbcf50fb",
 			"from": "radicle-drips@radicle-dev/drips-js-sdk#metadata-examples",
 			"requires": {}
 		},

--- a/nft-driver-examples/package-lock.json
+++ b/nft-driver-examples/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@walletconnect/web3-provider": "^1.2.2",
 				"ethers": "^5.7.2",
-				"radicle-drips": "github:radicle-dev/drips-js-sdk#get-subaccounts-by-associated-app",
+				"radicle-drips": "github:radicle-dev/drips-js-sdk#metadata-examples",
 				"svelte-json-tree": "^1.0.0",
 				"web3modal": "^1.9.9"
 			},
@@ -5528,7 +5528,7 @@
 		},
 		"node_modules/radicle-drips": {
 			"version": "2.0.0",
-			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#cd7fda68defba004be16b6ec7f517a3c53e6d891",
+			"resolved": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#96438515f870138ad3e686f58e1a032df49e9250",
 			"peerDependencies": {
 				"ethers": "^5.6.2"
 			}
@@ -11027,8 +11027,8 @@
 			"dev": true
 		},
 		"radicle-drips": {
-			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#cd7fda68defba004be16b6ec7f517a3c53e6d891",
-			"from": "radicle-drips@radicle-dev/drips-js-sdk#get-subaccounts-by-associated-app",
+			"version": "git+ssh://git@github.com/radicle-dev/drips-js-sdk.git#96438515f870138ad3e686f58e1a032df49e9250",
+			"from": "radicle-drips@radicle-dev/drips-js-sdk#metadata-examples",
 			"requires": {}
 		},
 		"randombytes": {

--- a/nft-driver-examples/package.json
+++ b/nft-driver-examples/package.json
@@ -35,7 +35,7 @@
 	"dependencies": {
 		"@walletconnect/web3-provider": "^1.2.2",
 		"ethers": "^5.7.2",
-		"radicle-drips": "github:radicle-dev/drips-js-sdk#get-subaccounts-by-associated-app",
+		"radicle-drips": "github:radicle-dev/drips-js-sdk#metadata-examples",
 		"svelte-json-tree": "^1.0.0",
 		"web3modal": "^1.9.9"
 	}

--- a/nft-driver-examples/src/routes/+page.svelte
+++ b/nft-driver-examples/src/routes/+page.svelte
@@ -61,6 +61,7 @@
 					<li><a href="/utils">Asset Helpers</a></li>
 					<li><a href="/utils">Cycle info</a></li>
 					<li><a href="/utils">Debug Drips Receiver Configuration</a></li>
+					<li><a href="/utils">Debug User Metadata</a></li>
 				</ul>
 			</li>
 		</ul>

--- a/nft-driver-examples/src/routes/+page.svelte
+++ b/nft-driver-examples/src/routes/+page.svelte
@@ -50,6 +50,12 @@
 				</ul>
 			</li>
 			<li>
+				Metadata:
+				<ul>
+					<li><a href="/metadata">Emit User Metadata</a></li>
+				</ul>
+			</li>
+			<li>
 				Utilities:
 				<ul>
 					<li><a href="/utils">Asset Helpers</a></li>

--- a/nft-driver-examples/src/routes/metadata/+page.svelte
+++ b/nft-driver-examples/src/routes/metadata/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { dripsClients } from '$lib/stores';
+	import { goto } from '$app/navigation';
+	import Emit from './Emit.svelte';
+
+	$: nftDriverClient = $dripsClients?.nftDriverClient;
+	$: subgraphClient = $dripsClients?.subgraphClient;
+</script>
+
+<svelte:head>
+	<title>Metadata</title>
+	<meta name="description" content="Emit user metadata" />
+</svelte:head>
+
+<div class="container">
+	<h1>Metadata</h1>
+	<Emit {nftDriverClient} />
+	<button class="btn btn-default btn-block" on:click={() => goto('/')}>Back to API explorer</button>
+</div>

--- a/nft-driver-examples/src/routes/metadata/Emit.svelte
+++ b/nft-driver-examples/src/routes/metadata/Emit.svelte
@@ -101,8 +101,8 @@
 					<ol>
 						{#each metadata as m}
 							<li>
-								<p>Key ('{Utils.UserMetadata.toHumanReadable(m).key}'): {m.key}</p>
-								<p>Key ('{Utils.UserMetadata.toHumanReadable(m).value}'): {m.value}</p>
+								<p>Key ('{Utils.UserMetadata.parseMetadataAsString(m).key}'): {m.key}</p>
+								<p>Key ('{Utils.UserMetadata.parseMetadataAsString(m).value}'): {m.value}</p>
 							</li>
 						{/each}
 					</ol>

--- a/nft-driver-examples/src/routes/metadata/Emit.svelte
+++ b/nft-driver-examples/src/routes/metadata/Emit.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { isConnected } from '$lib/stores';
+	import type { ContractReceipt, ContractTransaction } from 'ethers';
+	import type { NFTDriverClient, UserMetadataStruct } from 'radicle-drips';
+
+	export let nftDriverClient: NFTDriverClient | undefined;
+
+	type UserMetadataInput = {
+		key: string | undefined;
+		value: string | undefined;
+	};
+
+	const metadataInputs: UserMetadataInput[] = [
+		{
+			key: undefined,
+			value: undefined
+		},
+		{
+			key: undefined,
+			value: undefined
+		}
+	];
+
+	let emitting = false;
+	let tokenId: string;
+	let errorMessage: string | undefined;
+	let tx: ContractTransaction | undefined;
+	let txReceipt: ContractReceipt | undefined;
+
+	async function emitUserMetadata(tokenId: string) {
+		tx = undefined;
+		emitting = true;
+		txReceipt = undefined;
+		errorMessage = undefined;
+
+		const metadata: UserMetadataStruct[] = metadataInputs
+			.filter((m) => m.key && m.value)
+			.map((m) => ({ key: m.key as string, value: m.value as string }));
+
+		console.log(metadata);
+
+		try {
+			tx = await nftDriverClient?.emitUserMetadata(tokenId, metadata);
+			console.log(tx);
+
+			txReceipt = await tx?.wait();
+			console.log(txReceipt);
+		} catch (error: any) {
+			errorMessage = error.message;
+			console.error(error);
+		}
+
+		emitting = false;
+	}
+</script>
+
+<h2>Emit User Metadata</h2>
+
+<form>
+	<fieldset>
+		<legend>Parameters</legend>
+
+		<label for="configuredUserId">The ID of the token representing the emitting account:</label>
+		<div class="form-group">
+			<input
+				type="text"
+				name="configuredUserId"
+				placeholder="e.g., 26959946667150639794667015087019630673637144422540572481103610249216"
+				bind:value={tokenId}
+			/>
+		</div>
+
+		<div class="form-group">
+			{#each metadataInputs as metadataInput, i}
+				<div class="input-row form-group">
+					<span>{i + 1}# Metadata Entry:</span>
+					<input type="text" placeholder="Metadata key" bind:value={metadataInput.key} />
+					<input type="text" placeholder="Metadata value" bind:value={metadataInput.value} />
+				</div>
+			{/each}
+		</div>
+
+		<div>
+			<div class="form-group">
+				<button
+					class="btn btn-default"
+					type="button"
+					disabled={!$isConnected}
+					on:click={() => emitUserMetadata(tokenId)}>Emit</button
+				>
+			</div>
+
+			{#if !$isConnected}
+				<div class="terminal-alert terminal-alert-error">[Not Connected]</div>
+			{:else if errorMessage}
+				<div class="terminal-alert terminal-alert-error">
+					<p>{errorMessage}</p>
+				</div>
+			{:else if txReceipt}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>Updated ✅</p>
+					<p>
+						Wait for a few seconds and refresh to see the updated configuration. Sometimes the
+						Subgraph takes some time to update.
+					</p>
+				</div>
+			{:else if tx}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>Awaiting confirmations... ⏳</p>
+				</div>
+			{:else if emitting}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>Confirm the transaction 👉</p>
+				</div>
+			{/if}
+		</div>
+	</fieldset>
+</form>
+
+<hr />

--- a/nft-driver-examples/src/routes/metadata/Emit.svelte
+++ b/nft-driver-examples/src/routes/metadata/Emit.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { isConnected } from '$lib/stores';
-	import type { ContractReceipt, ContractTransaction } from 'ethers';
+	import { ethers, type ContractReceipt, type ContractTransaction } from 'ethers';
 	import type { NFTDriverClient, UserMetadataStruct } from 'radicle-drips';
 
 	export let nftDriverClient: NFTDriverClient | undefined;
@@ -34,8 +34,11 @@
 		errorMessage = undefined;
 
 		const metadata: UserMetadataStruct[] = metadataInputs
-			.filter((m) => m.key && m.value)
-			.map((m) => ({ key: m.key as string, value: m.value as string }));
+			.filter((m) => m.key?.length && m.value?.length)
+			.map((m) => ({
+				key: ethers.utils.formatBytes32String(m.key as string),
+				value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(m.value as string))
+			}));
 
 		console.log(metadata);
 

--- a/nft-driver-examples/src/routes/utils/+page.svelte
+++ b/nft-driver-examples/src/routes/utils/+page.svelte
@@ -5,6 +5,7 @@
 	import CycleInfo from './CycleInfo.svelte';
 	import { goto } from '$app/navigation';
 	import Asset from './Asset.svelte';
+	import UserMetadata from './UserMetadata.svelte';
 
 	$: nftDriverClient = $dripsClients?.nftDriverClient;
 </script>
@@ -19,5 +20,6 @@
 	<Asset />
 	<CycleInfo {nftDriverClient} />
 	<DripsReceiverConfig />
+	<UserMetadata />
 	<button class="btn btn-default btn-block" on:click={() => goto('/')}>Back to API explorer</button>
 </div>

--- a/nft-driver-examples/src/routes/utils/UserMetadata.svelte
+++ b/nft-driver-examples/src/routes/utils/UserMetadata.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+	import type { BytesLike } from 'ethers';
+	import { Utils } from 'radicle-drips';
+	import { isConnected } from '$lib/stores';
+
+	let createKeyInput: string;
+	let createKeyOutput: BytesLike;
+	let createKeyErrorMessage: string | undefined;
+
+	async function createKey(key: string) {
+		createKeyErrorMessage = undefined;
+
+		try {
+			createKeyOutput = Utils.UserMetadata.keyFromString(key);
+		} catch (error: any) {
+			console.error(error);
+			createKeyErrorMessage = error.message;
+		}
+	}
+
+	let createValueInput: string;
+	let createValueOutput: BytesLike;
+	let createValueErrorMessage: string | undefined;
+
+	async function createValue(value: string) {
+		createValueErrorMessage = undefined;
+
+		try {
+			createValueOutput = Utils.UserMetadata.valueFromString(value);
+		} catch (error: any) {
+			console.error(error);
+			createValueErrorMessage = error.message;
+		}
+	}
+
+	let readKeyInput: string;
+	let readKeyOutput: BytesLike;
+	let readKeyErrorMessage: string | undefined;
+
+	async function readKey(key: string) {
+		readKeyErrorMessage = undefined;
+
+		try {
+			// We don't need the value, pass and arbitrary value.
+			const value = Utils.UserMetadata.valueFromString('');
+			readKeyOutput = Utils.UserMetadata.toHumanReadable({ key, value }).key;
+		} catch (error: any) {
+			console.error(error);
+			readKeyErrorMessage = error.message;
+		}
+	}
+
+	let readValueInput: string;
+	let readValueOutput: BytesLike;
+	let readValueErrorMessage: string | undefined;
+
+	async function readValue(value: string) {
+		readValueErrorMessage = undefined;
+
+		try {
+			// We don't need the key, pass and arbitrary value.
+			const key = Utils.UserMetadata.keyFromString('');
+			readValueOutput = Utils.UserMetadata.toHumanReadable({ key, value }).value;
+		} catch (error: any) {
+			console.error(error);
+			readValueErrorMessage = error.message;
+		}
+	}
+</script>
+
+<h2>User Metadata (<code>Utils.UserMetadata</code>)</h2>
+
+<form>
+	<fieldset>
+		<legend>Create Metadata Key From String</legend>
+		<div class="form-group">
+			<label for="config">Key as string:</label>
+			<input
+				id="config"
+				name="config"
+				type="text"
+				placeholder="e.g., my-key"
+				bind:value={createKeyInput}
+			/>
+		</div>
+		<div class="form-group">
+			<button
+				class="btn btn-default"
+				disabled={!$isConnected}
+				type="button"
+				on:click={() => createKey(createKeyInput)}>Create Key</button
+			>
+		</div>
+
+		<div>
+			{#if !$isConnected}
+				<div class="terminal-alert terminal-alert-error">[Not Connected]</div>
+			{:else if createKeyErrorMessage}
+				<div class="terminal-alert terminal-alert-error">
+					<p>{createKeyErrorMessage}</p>
+				</div>
+			{:else if createKeyOutput}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>{createKeyOutput}</p>
+				</div>
+			{/if}
+		</div>
+	</fieldset>
+</form>
+
+<form class="form">
+	<fieldset>
+		<legend>Create Metadata Value From String</legend>
+		<div class="form-group">
+			<label for="config">Value as string:</label>
+			<input
+				id="config"
+				name="config"
+				type="text"
+				placeholder="e.g., my-value"
+				bind:value={createValueInput}
+			/>
+		</div>
+		<div class="form-group">
+			<button
+				class="btn btn-default"
+				disabled={!$isConnected}
+				type="button"
+				on:click={() => createValue(createValueInput)}>Create Value</button
+			>
+		</div>
+
+		<div>
+			{#if !$isConnected}
+				<div class="terminal-alert terminal-alert-error">[Not Connected]</div>
+			{:else if createValueErrorMessage}
+				<div class="terminal-alert terminal-alert-error">
+					<p>{createValueErrorMessage}</p>
+				</div>
+			{:else if createValueOutput}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>{createValueOutput}</p>
+				</div>
+			{/if}
+		</div>
+	</fieldset>
+</form>
+
+<form class="form">
+	<fieldset>
+		<legend>Read Metadata Key From BytesLike</legend>
+		<div class="form-group">
+			<label for="config">Key as BytesLike:</label>
+			<input
+				id="config"
+				name="config"
+				type="text"
+				placeholder="e.g., 0x6d792d6b65790000000000000000000000000000000000000000000000000000"
+				bind:value={readKeyInput}
+			/>
+		</div>
+		<div class="form-group">
+			<button
+				class="btn btn-default"
+				disabled={!$isConnected}
+				type="button"
+				on:click={() => readKey(readKeyInput)}>Read Key</button
+			>
+		</div>
+
+		<div>
+			{#if !$isConnected}
+				<div class="terminal-alert terminal-alert-error">[Not Connected]</div>
+			{:else if readKeyErrorMessage}
+				<div class="terminal-alert terminal-alert-error">
+					<p>{readKeyErrorMessage}</p>
+				</div>
+			{:else if readKeyOutput}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>{readKeyOutput}</p>
+				</div>
+			{/if}
+		</div>
+	</fieldset>
+</form>
+
+<form class="form">
+	<fieldset>
+		<legend>Read Metadata Value From BytesLike</legend>
+		<div class="form-group">
+			<label for="config">Value as BytesLike:</label>
+			<input
+				id="config"
+				name="config"
+				type="text"
+				placeholder="e.g., 0x6d792d76616c"
+				bind:value={readValueInput}
+			/>
+		</div>
+		<div class="form-group">
+			<button
+				class="btn btn-default"
+				disabled={!$isConnected}
+				type="button"
+				on:click={() => readValue(readValueInput)}>Read Value</button
+			>
+		</div>
+
+		<div>
+			{#if !$isConnected}
+				<div class="terminal-alert terminal-alert-error">[Not Connected]</div>
+			{:else if readValueErrorMessage}
+				<div class="terminal-alert terminal-alert-error">
+					<p>{readValueErrorMessage}</p>
+				</div>
+			{:else if readValueOutput}
+				<div class="terminal-alert terminal-alert-primary">
+					<p>{readValueOutput}</p>
+				</div>
+			{/if}
+		</div>
+	</fieldset>
+</form>
+
+<hr />
+
+<style>
+	.form {
+		margin: calc(var(--global-space) * 2) 0;
+	}
+</style>

--- a/nft-driver-examples/src/routes/utils/UserMetadata.svelte
+++ b/nft-driver-examples/src/routes/utils/UserMetadata.svelte
@@ -43,7 +43,7 @@
 		try {
 			// We don't need the value, pass and arbitrary value.
 			const value = Utils.UserMetadata.valueFromString('');
-			readKeyOutput = Utils.UserMetadata.toHumanReadable({ key, value }).key;
+			readKeyOutput = Utils.UserMetadata.parseMetadataAsString({ key, value }).key;
 		} catch (error: any) {
 			console.error(error);
 			readKeyErrorMessage = error.message;
@@ -60,7 +60,7 @@
 		try {
 			// We don't need the key, pass and arbitrary value.
 			const key = Utils.UserMetadata.keyFromString('');
-			readValueOutput = Utils.UserMetadata.toHumanReadable({ key, value }).value;
+			readValueOutput = Utils.UserMetadata.parseMetadataAsString({ key, value }).value;
 		} catch (error: any) {
 			console.error(error);
 			readValueErrorMessage = error.message;

--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -326,8 +326,9 @@ export default class AddressDriverClient {
 	/**
 	 * Emits the user's metadata.
 	 * The key and the value are _not_ standardized by the protocol, it's up to the user to establish and follow conventions to ensure compatibility with the consumers.
-	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata.
-	 * @returns A `Promise` which resolves to the contract transaction.
+	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
+	 *
+	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.	 * @returns A `Promise` which resolves to the contract transaction.
 	 * @throws {@link DripsErrors.argumentError} if any of the metadata entries is not valid.
 	 * @throws {@link DripsErrors.signerMissingError} if the provider's signer is missing.
 	 */

--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -328,7 +328,8 @@ export default class AddressDriverClient {
 	 * The key and the value are _not_ standardized by the protocol, it's up to the user to establish and follow conventions to ensure compatibility with the consumers.
 	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
 	 *
-	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.	 * @returns A `Promise` which resolves to the contract transaction.
+	 * **Tip**: you might want to use `Utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
+	 * @returns A `Promise` which resolves to the contract transaction.
 	 * @throws {@link DripsErrors.argumentError} if any of the metadata entries is not valid.
 	 * @throws {@link DripsErrors.signerMissingError} if the provider's signer is missing.
 	 */

--- a/src/DripsSubgraph/DripsSubgraphClient.ts
+++ b/src/DripsSubgraph/DripsSubgraphClient.ts
@@ -370,7 +370,7 @@ export default class DripsSubgraphClient {
 	 * Returns the token IDs that are associated with the given app identifier.
 	 * @param  {BytesLike} associatedApp The name/ID of the app to retrieve accounts for.
 	 *
-	 * Tip: you might want to use `ethers.utils.formatBytes32String(associatedAppAsString)` to create your `associatedApp` argument from a `string`.
+	 * **Tip**: you might want to use `ethers.utils.hexlify(ethers.utils.toUtf8Bytes(associatedAppAsString))` to create your `associatedApp` argument from a `string`.
 	 * @returns A `Promise` which resolves to the account IDs.
 	 * @throws {@link DripsErrors.argumentError} if the `associatedApp` is missing.
 	 * @throws {@link DripsErrors.subgraphQueryError} if the query fails.

--- a/src/DripsSubgraph/DripsSubgraphClient.ts
+++ b/src/DripsSubgraph/DripsSubgraphClient.ts
@@ -370,7 +370,7 @@ export default class DripsSubgraphClient {
 	 * Returns the token IDs that are associated with the given app identifier.
 	 * @param  {BytesLike} associatedApp The name/ID of the app to retrieve accounts for.
 	 *
-	 * **Tip**: you might want to use `ethers.utils.hexlify(ethers.utils.toUtf8Bytes(associatedAppAsString))` to create your `associatedApp` argument from a `string`.
+	 * **Tip**: you might want to use `Utils.UserMetadata.valueFromString` to create your `associatedApp` argument from a `string`.
 	 * @returns A `Promise` which resolves to the account IDs.
 	 * @throws {@link DripsErrors.argumentError} if the `associatedApp` is missing.
 	 * @throws {@link DripsErrors.subgraphQueryError} if the query fails.

--- a/src/ImmutableSplits/ImmutableSplitsDriver.ts
+++ b/src/ImmutableSplits/ImmutableSplitsDriver.ts
@@ -73,8 +73,9 @@ export default class ImmutableSplitsDriverClient {
 	 * The configuration is immutable and nobody can control the user ID after its creation.
 	 * Calling this function is the only way and the only chance to emit metadata for that user.
 	 * @param  {SplitsReceiverStruct[]} receivers The splits receivers.
-	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata to emit for the created user.
-	 * The key and the value are _not_ standardized by the protocol, it's up to the user to establish and follow conventions to ensure compatibility with the consumers.
+	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata to emit for the created user. Note that a metadata `key` needs to be 32bytes.
+	 *
+	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to the contract transaction.
 	 * @throws {@link DripsErrors.argumentMissingError} if the `receivers` are missing.
 	 * @throws {@link DripsErrors.splitsReceiverError} if any of the `receivers` is not valid.

--- a/src/ImmutableSplits/ImmutableSplitsDriver.ts
+++ b/src/ImmutableSplits/ImmutableSplitsDriver.ts
@@ -75,7 +75,7 @@ export default class ImmutableSplitsDriverClient {
 	 * @param  {SplitsReceiverStruct[]} receivers The splits receivers.
 	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata to emit for the created user. Note that a metadata `key` needs to be 32bytes.
 	 *
-	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
+	 * **Tip**: you might want to use `Utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to the contract transaction.
 	 * @throws {@link DripsErrors.argumentMissingError} if the `receivers` are missing.
 	 * @throws {@link DripsErrors.splitsReceiverError} if any of the `receivers` is not valid.

--- a/src/NFTDriver/NFTDriverClient.ts
+++ b/src/NFTDriver/NFTDriverClient.ts
@@ -135,7 +135,9 @@ export default class NFTDriverClient {
 	 * If provided, the following user metadata entry will be appended to the `userMetadata` list:
 	 * - key: "associatedApp"
 	 * - value: `associatedApp`.
-	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata.
+	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
+	 *
+	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to minted token ID. It's equal to the user ID controlled by it.
 	 * @throws {@link DripsErrors.argumentMissingError} if the `transferToAddress` is missing.
 	 * @throws {@link DripsErrors.addressError} if the `transferToAddress` is not valid.
@@ -185,7 +187,9 @@ export default class NFTDriverClient {
 	 * The name/ID of the app that is associated with the new account.
 	 * If provided, the following user metadata entry will be appended to the `userMetadata` list:
 	 * - key: "associatedApp"
-	 * - value: `associatedApp`.	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata.
+	 * - value: `associatedApp`.	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
+	 *
+	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to minted token ID. It's equal to the user ID controlled by it.
 	 * @throws {@link DripsErrors.argumentMissingError} if the `transferToAddress` is missing.
 	 * @throws {@link DripsErrors.addressError} if the `transferToAddress` is not valid.
@@ -402,7 +406,9 @@ export default class NFTDriverClient {
 	 *
 	 * The caller (client's `signer`) must be the owner of the `tokenId` or be approved to use it.
 	 * @param  {string} tokenId The ID of the token representing the emitting account.
-	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata.
+	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
+	 *
+	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to the contract transaction.
 	 * @throws {@link DripsErrors.argumentError} if any of the metadata entries is not valid.
 	 */

--- a/src/NFTDriver/NFTDriverClient.ts
+++ b/src/NFTDriver/NFTDriverClient.ts
@@ -165,7 +165,7 @@ export default class NFTDriverClient {
 		const txResponse = await this.#driver.mint(transferToAddress, userMetadata);
 
 		const txReceipt = await txResponse.wait();
-		const transferEvent = txReceipt.events!.filter((e) => e.event!.toLowerCase() === 'transfer')[0]!;
+		const transferEvent = txReceipt.events!.filter((e) => e.event?.toLowerCase() === 'transfer')[0]!;
 		const { tokenId } = transferEvent.args!;
 
 		return BigInt(tokenId).toString();
@@ -217,7 +217,7 @@ export default class NFTDriverClient {
 		const txResponse = await this.#driver.safeMint(transferToAddress, userMetadata);
 
 		const txReceipt = await txResponse.wait();
-		const transferEvent = txReceipt.events!.filter((e) => e.event!.toLowerCase() === 'transfer')[0]!;
+		const transferEvent = txReceipt.events!.filter((e) => e.event?.toLowerCase() === 'transfer')[0]!;
 		const { tokenId } = transferEvent.args!;
 
 		return BigInt(tokenId).toString();

--- a/src/NFTDriver/NFTDriverClient.ts
+++ b/src/NFTDriver/NFTDriverClient.ts
@@ -137,7 +137,7 @@ export default class NFTDriverClient {
 	 * - value: `associatedApp`.
 	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
 	 *
-	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
+	 * **Tip**: you might want to use `Utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to minted token ID. It's equal to the user ID controlled by it.
 	 * @throws {@link DripsErrors.argumentMissingError} if the `transferToAddress` is missing.
 	 * @throws {@link DripsErrors.addressError} if the `transferToAddress` is not valid.
@@ -189,7 +189,7 @@ export default class NFTDriverClient {
 	 * - key: "associatedApp"
 	 * - value: `associatedApp`.	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
 	 *
-	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
+	 * **Tip**: you might want to use `Utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to minted token ID. It's equal to the user ID controlled by it.
 	 * @throws {@link DripsErrors.argumentMissingError} if the `transferToAddress` is missing.
 	 * @throws {@link DripsErrors.addressError} if the `transferToAddress` is not valid.
@@ -408,7 +408,7 @@ export default class NFTDriverClient {
 	 * @param  {string} tokenId The ID of the token representing the emitting account.
 	 * @param  {UserMetadataStruct[]} userMetadata The list of user metadata. Note that a metadata `key` needs to be 32bytes.
 	 *
-	 * **Tip**: you might want to use `utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
+	 * **Tip**: you might want to use `Utils.UserMetadata.createFromStrings` to easily create metadata instances from `string` inputs.
 	 * @returns A `Promise` which resolves to the contract transaction.
 	 * @throws {@link DripsErrors.argumentError} if any of the metadata entries is not valid.
 	 */

--- a/src/common/DripsError.ts
+++ b/src/common/DripsError.ts
@@ -44,10 +44,16 @@ export class DripsErrors {
 			unsupportedChainId: chainId
 		});
 
-	static argumentError = (message: string, argName: string, argValue: unknown) =>
-		new DripsError(DripsErrorCode.INVALID_ARGUMENT, message, {
-			invalidArgument: { name: argName, value: argValue }
-		});
+	static argumentError = (message: string, argName?: string, argValue?: unknown) =>
+		new DripsError(
+			DripsErrorCode.INVALID_ARGUMENT,
+			message,
+			argName
+				? {
+						invalidArgument: { name: argName, value: argValue }
+				  }
+				: undefined
+		);
 
 	static splitsReceiverError = (message: string, invalidPropertyName: string, invalidPropertyValue: unknown) =>
 		new DripsError(DripsErrorCode.INVALID_SPLITS_RECEIVER, message, {

--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -213,11 +213,11 @@ export const validateEmitUserMetadataInput = (metadata: UserMetadataStruct[]) =>
 	metadata?.forEach((meta) => {
 		const { key, value } = meta;
 
-		if (!key) {
+		if (isNullOrUndefined(key)) {
 			throw DripsErrors.argumentError(`Invalid user metadata: '${nameOf({ key })}' is missing.`, nameOf({ key }), key);
 		}
 
-		if (!value) {
+		if (isNullOrUndefined(value)) {
 			throw DripsErrors.argumentError(
 				`Invalid user metadata: '${nameOf({ value })}' is missing.`,
 				nameOf({ value }),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,11 +39,11 @@ namespace Utils {
 		});
 
 		/**
-		 * Returns the given user metadata object in a human readable form.
+		 * Parses the properties of the given user metadata as `string`s.
 		 * @param  {UserMetadataStruct} userMetadata The user metadata.
 		 * @returns An object with the same properties as the `userMetadata` but with `string` properties instead of `BytesLike`.
 		 */
-		export const toHumanReadable = (userMetadata: UserMetadataStruct): { key: string; value: string } => {
+		export const parseMetadataAsString = (userMetadata: UserMetadataStruct): { key: string; value: string } => {
 			if (!ethers.utils.isBytesLike(userMetadata?.key) || !ethers.utils.isBytesLike(userMetadata?.value)) {
 				throw DripsErrors.argumentError(
 					`Invalid key-value user metadata pair: key or value is not a valid BytesLike object.`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,35 @@
 import type { BigNumberish } from 'ethers';
 import { BigNumber, ethers } from 'ethers';
 import { DripsErrors } from './common/DripsError';
-import type { NetworkConfig, CycleInfo, DripsReceiverConfig } from './common/types';
+import { nameOf } from './common/internals';
+import type { NetworkConfig, CycleInfo, DripsReceiverConfig, UserMetadataStruct } from './common/types';
 import { validateAddress, validateDripsReceiverConfig } from './common/validators';
 
 namespace Utils {
+	export namespace UserMetadata {
+		/**
+		 * Creates a user metadata object in the format the Drips protocol expects, from `string` inputs.
+		 *
+		 * @param  {string} key The metadata key.
+		 * @param  {string} value The metadata value.
+		 * @returns UserMetadataStruct the user metadata object.
+		 */
+		export const createFromStrings = (key: string, value: string): UserMetadataStruct => {
+			if (!key || !value) {
+				throw DripsErrors.argumentError(
+					`Invalid key-value user metadata pair: ${nameOf({ key })} and ${nameOf({ value })} are required.`,
+					key ? nameOf({ value }) : nameOf({ key }),
+					key ? value : key
+				);
+			}
+
+			return {
+				key: ethers.utils.formatBytes32String(key),
+				value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(value))
+			};
+		};
+	}
+
 	export namespace Network {
 		export const configs: Record<number, NetworkConfig> = {
 			5: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,33 +1,49 @@
-import type { BigNumberish } from 'ethers';
+import type { BigNumberish, BytesLike } from 'ethers';
 import { BigNumber, ethers } from 'ethers';
 import { DripsErrors } from './common/DripsError';
-import { nameOf } from './common/internals';
 import type { NetworkConfig, CycleInfo, DripsReceiverConfig, UserMetadataStruct } from './common/types';
 import { validateAddress, validateDripsReceiverConfig } from './common/validators';
 
 namespace Utils {
 	export namespace UserMetadata {
 		/**
-		 * Creates a user metadata object in the format the Drips protocol expects, from `string` inputs.
+		 * Creates a user metadata key in the format the Drips protocol expects from the given `string`.
+		 * @param  {string} key The metadata key.
+		 * @returns The metadata key as BytesLike.
+		 */
+		export const keyFromString = (key: string): BytesLike => ethers.utils.formatBytes32String(key);
+
+		/**
+		 * Creates a user metadata value in the format the Drips protocol expects from the given `string`.
+		 * @param  {string} value The metadata key.
+		 * @returns The metadata value as BytesLike.
+		 */
+		export const valueFromString = (value: string): BytesLike => ethers.utils.hexlify(ethers.utils.toUtf8Bytes(value));
+
+		/**
+		 * Creates a user metadata object in the format the Drips protocol expects from the given `string` inputs.
 		 *
 		 * @param  {string} key The metadata key.
 		 * @param  {string} value The metadata value.
-		 * @returns UserMetadataStruct the user metadata object.
+		 * @returns The user metadata.
 		 */
-		export const createFromStrings = (key: string, value: string): UserMetadataStruct => {
-			if (!key || !value) {
-				throw DripsErrors.argumentError(
-					`Invalid key-value user metadata pair: ${nameOf({ key })} and ${nameOf({ value })} are required.`,
-					key ? nameOf({ value }) : nameOf({ key }),
-					key ? value : key
-				);
-			}
+		export const createFromStrings = (key: string, value: string): UserMetadataStruct => ({
+			key: keyFromString(key),
+			value: valueFromString(value)
+		});
 
-			return {
-				key: ethers.utils.formatBytes32String(key),
-				value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(value))
-			};
-		};
+		/**
+		 * Returns the given user metadata object in a human readable form.
+		 * @param  {UserMetadataStruct} userMetadata The user metadata.
+		 * @returns An object with the same properties as the `userMetadata` but with `string` properties instead of `BytesLike`.
+		 */
+		export const toHumanReadable = (userMetadata: {
+			key: BytesLike;
+			value: BytesLike;
+		}): { key: string; value: string } => ({
+			key: ethers.utils.parseBytes32String(userMetadata.key),
+			value: ethers.utils.toUtf8String(userMetadata.value)
+		});
 	}
 
 	export namespace Network {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import type { BigNumberish, BytesLike } from 'ethers';
 import { BigNumber, ethers } from 'ethers';
 import { DripsErrors } from './common/DripsError';
-import type { NetworkConfig, CycleInfo, DripsReceiverConfig, UserMetadataStruct } from './common/types';
+import type { NetworkConfig, CycleInfo, DripsReceiverConfig } from './common/types';
 import { validateAddress, validateDripsReceiverConfig } from './common/validators';
 
 namespace Utils {
@@ -27,7 +27,13 @@ namespace Utils {
 		 * @param  {string} value The metadata value.
 		 * @returns The user metadata.
 		 */
-		export const createFromStrings = (key: string, value: string): UserMetadataStruct => ({
+		export const createFromStrings = (
+			key: string,
+			value: string
+		): {
+			key: BytesLike;
+			value: BytesLike;
+		} => ({
 			key: keyFromString(key),
 			value: valueFromString(value)
 		});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import type { BigNumberish, BytesLike } from 'ethers';
 import { BigNumber, ethers } from 'ethers';
 import { DripsErrors } from './common/DripsError';
-import type { NetworkConfig, CycleInfo, DripsReceiverConfig } from './common/types';
+import type { NetworkConfig, CycleInfo, DripsReceiverConfig, UserMetadataStruct } from './common/types';
 import { validateAddress, validateDripsReceiverConfig } from './common/validators';
 
 namespace Utils {
@@ -43,13 +43,18 @@ namespace Utils {
 		 * @param  {UserMetadataStruct} userMetadata The user metadata.
 		 * @returns An object with the same properties as the `userMetadata` but with `string` properties instead of `BytesLike`.
 		 */
-		export const toHumanReadable = (userMetadata: {
-			key: BytesLike;
-			value: BytesLike;
-		}): { key: string; value: string } => ({
-			key: ethers.utils.parseBytes32String(userMetadata.key),
-			value: ethers.utils.toUtf8String(userMetadata.value)
-		});
+		export const toHumanReadable = (userMetadata: UserMetadataStruct): { key: string; value: string } => {
+			if (!ethers.utils.isBytesLike(userMetadata?.key) || !ethers.utils.isBytesLike(userMetadata?.value)) {
+				throw DripsErrors.argumentError(
+					`Invalid key-value user metadata pair: key or value is not a valid BytesLike object.`
+				);
+			}
+
+			return {
+				key: ethers.utils.parseBytes32String(userMetadata.key),
+				value: ethers.utils.toUtf8String(userMetadata.value)
+			};
+		};
 	}
 
 	export namespace Network {

--- a/tests/NFTDriver/NFTDriverClient.tests.ts
+++ b/tests/NFTDriver/NFTDriverClient.tests.ts
@@ -407,6 +407,25 @@ describe('NFTDriverClient', () => {
 			assert(validateEmitUserMetadataInputStub.calledOnceWithExactly(metadata));
 		});
 
+		it('should throw an argumentError when associatedApp is not BytesLike', async () => {
+			let threw = false;
+			const metadata: UserMetadataStruct[] = [{ key: 'key', value: 'value' }];
+
+			const transferToAddress = Wallet.createRandom().address;
+
+			try {
+				// Act
+				await testNftDriverClient.safeCreateAccount(transferToAddress, 'invalid BytesLike string', metadata);
+			} catch (error: any) {
+				// Assert
+				assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+				threw = true;
+			}
+
+			// Assert
+			assert.isTrue(threw, 'Expected type of exception was not thrown');
+		});
+
 		it('should not set an associated app metadata entry when an associated app is not provided', async () => {
 			// Arrange
 			const expectedTokenId = '1';

--- a/tests/utils.tests.ts
+++ b/tests/utils.tests.ts
@@ -12,6 +12,53 @@ describe('Utils', () => {
 		sinon.restore();
 	});
 
+	describe('UserMetadata', () => {
+		describe('createFromStrings', () => {
+			it('should throw argumentError when key is missing', async () => {
+				// Arrange
+				let threw = false;
+
+				// Act
+				try {
+					Utils.UserMetadata.createFromStrings(undefined as unknown as string, 'value');
+				} catch (error: any) {
+					// Assert
+					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+					threw = true;
+				}
+
+				// Assert
+				assert.isTrue(threw, 'Expected type of exception was not thrown');
+			});
+
+			it('should throw argumentError when value is missing', async () => {
+				// Arrange
+				let threw = false;
+
+				// Act
+				try {
+					Utils.UserMetadata.createFromStrings('key', undefined as unknown as string);
+				} catch (error: any) {
+					// Assert
+					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+					threw = true;
+				}
+
+				// Assert
+				assert.isTrue(threw, 'Expected type of exception was not thrown');
+			});
+
+			it('should return the expected result', () => {
+				// Act
+				const metadata = Utils.UserMetadata.createFromStrings('key', 'value');
+
+				// Assert
+				assert.equal(metadata.key, ethers.utils.formatBytes32String('key'));
+				assert.equal(metadata.value, ethers.utils.hexlify(ethers.utils.toUtf8Bytes('value')));
+			});
+		});
+	});
+
 	describe('Cycle', () => {
 		describe('getInfo()', () => {
 			it('should throw unsupportedNetworkError when the provided chain ID is not supported', async () => {

--- a/tests/utils.tests.ts
+++ b/tests/utils.tests.ts
@@ -46,6 +46,40 @@ describe('Utils', () => {
 		});
 
 		describe('toHumanReadable', () => {
+			it('should throw argumentError user metadata key is not a valid BytesLike object', async () => {
+				// Arrange
+				let threw = false;
+
+				// Act
+				try {
+					Utils.UserMetadata.toHumanReadable({ key: undefined as unknown as string, value: 'value' });
+				} catch (error: any) {
+					// Assert
+					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+					threw = true;
+				}
+
+				// Assert
+				assert.isTrue(threw, 'Expected type of exception was not thrown');
+			});
+
+			it('should throw argumentError user metadata value is not a valid BytesLike object', async () => {
+				// Arrange
+				let threw = false;
+
+				// Act
+				try {
+					Utils.UserMetadata.toHumanReadable({ key: 'key', value: undefined as unknown as string });
+				} catch (error: any) {
+					// Assert
+					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+					threw = true;
+				}
+
+				// Assert
+				assert.isTrue(threw, 'Expected type of exception was not thrown');
+			});
+
 			it('should return the expected result', () => {
 				// Act
 				const key: BytesLike = Utils.UserMetadata.keyFromString('key');

--- a/tests/utils.tests.ts
+++ b/tests/utils.tests.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import type { BytesLike } from 'ethers';
 import { BigNumber, ethers } from 'ethers';
 import sinon from 'ts-sinon';
 import { DripsErrorCode } from '../src/common/DripsError';
@@ -13,48 +14,48 @@ describe('Utils', () => {
 	});
 
 	describe('UserMetadata', () => {
+		describe('keyFromString', () => {
+			it('should return the expected result', () => {
+				// Act
+				const key = Utils.UserMetadata.keyFromString('key');
+
+				// Assert
+				assert.equal(key, ethers.utils.formatBytes32String('key'));
+			});
+		});
+
+		describe('valueFromString', () => {
+			it('should return the expected result', () => {
+				// Act
+				const value = Utils.UserMetadata.valueFromString('value');
+
+				// Assert
+				assert.equal(value, ethers.utils.hexlify(ethers.utils.toUtf8Bytes('value')));
+			});
+		});
+
 		describe('createFromStrings', () => {
-			it('should throw argumentError when key is missing', async () => {
-				// Arrange
-				let threw = false;
-
-				// Act
-				try {
-					Utils.UserMetadata.createFromStrings(undefined as unknown as string, 'value');
-				} catch (error: any) {
-					// Assert
-					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
-					threw = true;
-				}
-
-				// Assert
-				assert.isTrue(threw, 'Expected type of exception was not thrown');
-			});
-
-			it('should throw argumentError when value is missing', async () => {
-				// Arrange
-				let threw = false;
-
-				// Act
-				try {
-					Utils.UserMetadata.createFromStrings('key', undefined as unknown as string);
-				} catch (error: any) {
-					// Assert
-					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
-					threw = true;
-				}
-
-				// Assert
-				assert.isTrue(threw, 'Expected type of exception was not thrown');
-			});
-
 			it('should return the expected result', () => {
 				// Act
 				const metadata = Utils.UserMetadata.createFromStrings('key', 'value');
 
 				// Assert
-				assert.equal(metadata.key, ethers.utils.formatBytes32String('key'));
-				assert.equal(metadata.value, ethers.utils.hexlify(ethers.utils.toUtf8Bytes('value')));
+				assert.equal(metadata.key, Utils.UserMetadata.keyFromString('key'));
+				assert.equal(metadata.value, Utils.UserMetadata.valueFromString('value'));
+			});
+		});
+
+		describe('toHumanReadable', () => {
+			it('should return the expected result', () => {
+				// Act
+				const key: BytesLike = Utils.UserMetadata.keyFromString('key');
+				const value: BytesLike = Utils.UserMetadata.valueFromString('value');
+
+				const metadata = Utils.UserMetadata.toHumanReadable({ key, value });
+
+				// Assert
+				assert.equal(metadata.key, 'key');
+				assert.equal(metadata.value, 'value');
 			});
 		});
 	});

--- a/tests/utils.tests.ts
+++ b/tests/utils.tests.ts
@@ -45,14 +45,14 @@ describe('Utils', () => {
 			});
 		});
 
-		describe('toHumanReadable', () => {
+		describe('parseMetadataAsString', () => {
 			it('should throw argumentError user metadata key is not a valid BytesLike object', async () => {
 				// Arrange
 				let threw = false;
 
 				// Act
 				try {
-					Utils.UserMetadata.toHumanReadable({ key: undefined as unknown as string, value: 'value' });
+					Utils.UserMetadata.parseMetadataAsString({ key: undefined as unknown as string, value: 'value' });
 				} catch (error: any) {
 					// Assert
 					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
@@ -69,7 +69,7 @@ describe('Utils', () => {
 
 				// Act
 				try {
-					Utils.UserMetadata.toHumanReadable({ key: 'key', value: undefined as unknown as string });
+					Utils.UserMetadata.parseMetadataAsString({ key: 'key', value: undefined as unknown as string });
 				} catch (error: any) {
 					// Assert
 					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
@@ -85,7 +85,7 @@ describe('Utils', () => {
 				const key: BytesLike = Utils.UserMetadata.keyFromString('key');
 				const value: BytesLike = Utils.UserMetadata.valueFromString('value');
 
-				const metadata = Utils.UserMetadata.toHumanReadable({ key, value });
+				const metadata = Utils.UserMetadata.parseMetadataAsString({ key, value });
 
 				// Assert
 				assert.equal(metadata.key, 'key');


### PR DESCRIPTION
- Adds helpers for manipulating user metadata (strings <=> bytes)
- Adds UI examples
- Adds a `getNftSubAccountIdsByApp` query method

Feel free to skip the UI files and focus only on the SDK changes.

Merge after https://github.com/radicle-dev/drips-js-sdk/pull/84