### PR TITLE
Add helper method for getting current Drips receivers

### DIFF
--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -275,6 +275,8 @@ export default class AddressDriverClient {
 	 * If you use such tokens in the protocol, they can get stuck or lost.
 	 * @param  {DripsReceiverStruct[]} currentReceivers The drips receivers that were set in the last drips update.
 	 * Pass an empty array if this is the first update.
+	 *
+	 * **Tip**: you might want to use `DripsSubgraphClient.getCurrentDripsReceivers` to easily retrieve the list of current receivers.
 	 * @param  {DripsReceiverStruct[]} newReceivers The new drips receivers (max `100`).
 	 * Duplicate receivers are not allowed and will only be processed once.
 	 * Pass an empty array if you want to clear all receivers.

--- a/src/NFTDriver/NFTDriverClient.ts
+++ b/src/NFTDriver/NFTDriverClient.ts
@@ -333,6 +333,8 @@ export default class NFTDriverClient {
 	 * If you use such tokens in the protocol, they can get stuck or lost.
 	 * @param  {DripsReceiverStruct[]} currentReceivers The drips receivers that were set in the last drips update.
 	 * Pass an empty array if this is the first update.
+	 *
+	 * **Tip**: you might want to use `DripsSubgraphClient.getCurrentDripsReceivers` to easily retrieve the list of current receivers.
 	 * @param  {DripsReceiverStruct[]} newReceivers The new drips receivers (max `100`).
 	 * Duplicate receivers are not allowed and will only be processed once.
 	 * Pass an empty array  if you want to clear all receivers.

--- a/tests/AddressDriver/AddressDriverClient.integration.tests.ts
+++ b/tests/AddressDriver/AddressDriverClient.integration.tests.ts
@@ -52,10 +52,7 @@ describe('AddressDriver integration tests', () => {
 		console.log(`Updating Drips configuration...`);
 		await account2AddressDriverClient.setDrips(
 			WETH,
-			wEthConfigurationBefore?.dripsEntries.map((d) => ({
-				config: d.config,
-				userId: d.userId
-			})) || [],
+			await subgraphClient.getCurrentDripsReceivers(userId2, WETH),
 			[{ config, userId: userId1 }],
 			account2
 		);
@@ -91,10 +88,7 @@ describe('AddressDriver integration tests', () => {
 		console.log(`Clearing WETH configuration receivers...`);
 		await account2AddressDriverClient.setDrips(
 			WETH,
-			expectedConfig.dripsEntries.map((d) => ({
-				config: d.config,
-				userId: d.userId
-			})),
+			await subgraphClient.getCurrentDripsReceivers(userId2, WETH),
 			[],
 			account2
 		);

--- a/tests/NFTDriver/NFTDriverClient.integration.tests.ts
+++ b/tests/NFTDriver/NFTDriverClient.integration.tests.ts
@@ -114,10 +114,7 @@ describe('NFTDriver integration tests', () => {
 		await account2NftDriverClient.setDrips(
 			testSubAccount.tokenId,
 			WETH,
-			wEthConfigurationBefore?.dripsEntries.map((d) => ({
-				config: d.config,
-				userId: d.userId
-			})) || [],
+			await subgraphClient.getCurrentDripsReceivers(testSubAccount.tokenId, WETH),
 			[{ config, userId: receiver.tokenId }],
 			account2
 		);
@@ -154,10 +151,7 @@ describe('NFTDriver integration tests', () => {
 		await account2NftDriverClient.setDrips(
 			testSubAccount.tokenId,
 			WETH,
-			expectedConfig.dripsEntries.map((d) => ({
-				config: d.config,
-				userId: d.userId
-			})),
+			await subgraphClient.getCurrentDripsReceivers(testSubAccount.tokenId, WETH),
 			[],
 			account2
 		);


### PR DESCRIPTION
implementation avoids the Subgraph bug not returning the expected result

re https://github.com/radicle-dev/drips-js-sdk/issues/104
re https://github.com/radicle-dev/drips-js-sdk/issues/101