### PR TITLE
Generic fixes

### DIFF
--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -383,13 +383,15 @@ export default class AddressDriverClient {
 			);
 		}
 
-		// const mid64BitsMask = ethers.BigNumber.from(2).pow(64).sub(1).shl(160);
+		if (Utils.UserId.getDriver(userId) === 'address') {
+			const mid64BitsMask = ethers.BigNumber.from(2).pow(64).sub(1).shl(160);
 
-		// if (!userIdAsBn.and(mid64BitsMask).isZero()) {
-		// 	throw DripsErrors.argumentError(
-		// 		`Could not get user address: ${userId} is not a valid user ID. The first 64 (after first 32) bits must be 0.`
-		// 	);
-		// }
+			if (!userIdAsBn.and(mid64BitsMask).isZero()) {
+				throw DripsErrors.argumentError(
+					`Could not get user address: ${userId} is not a valid user ID. The first 64 (after first 32) bits must be 0.`
+				);
+			}
+		}
 
 		const mask = ethers.BigNumber.from(2).pow(160).sub(1);
 		const address = userIdAsBn.and(mask).toHexString();

--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -377,19 +377,19 @@ export default class AddressDriverClient {
 
 		const userIdAsBn = ethers.BigNumber.from(userId);
 
-		// if (userIdAsBn.lt(0) || userIdAsBn.gt(ethers.constants.MaxUint256)) {
-		// 	throw DripsErrors.argumentError(
-		// 		`Could not get user address: ${userId} is not a valid positive number within the range of a uint256.`
-		// 	);
-		// }
-
-		const mid64BitsMask = ethers.BigNumber.from(2).pow(64).sub(1).shl(160);
-
-		if (!userIdAsBn.and(mid64BitsMask).isZero()) {
+		if (userIdAsBn.lt(0) || userIdAsBn.gt(ethers.constants.MaxUint256)) {
 			throw DripsErrors.argumentError(
-				`Could not get user address: ${userId} is not a valid user ID. The first 64 (after first 32) bits must be 0.`
+				`Could not get user address: ${userId} is not a valid positive number within the range of a uint256.`
 			);
 		}
+
+		// const mid64BitsMask = ethers.BigNumber.from(2).pow(64).sub(1).shl(160);
+
+		// if (!userIdAsBn.and(mid64BitsMask).isZero()) {
+		// 	throw DripsErrors.argumentError(
+		// 		`Could not get user address: ${userId} is not a valid user ID. The first 64 (after first 32) bits must be 0.`
+		// 	);
+		// }
 
 		const mask = ethers.BigNumber.from(2).pow(160).sub(1);
 		const address = userIdAsBn.and(mask).toHexString();

--- a/src/AddressDriver/AddressDriverClient.ts
+++ b/src/AddressDriver/AddressDriverClient.ts
@@ -377,11 +377,11 @@ export default class AddressDriverClient {
 
 		const userIdAsBn = ethers.BigNumber.from(userId);
 
-		if (userIdAsBn.lt(0) || userIdAsBn.gt(ethers.constants.MaxUint256)) {
-			throw DripsErrors.argumentError(
-				`Could not get user address: ${userId} is not a valid positive number within the range of a uint256.`
-			);
-		}
+		// if (userIdAsBn.lt(0) || userIdAsBn.gt(ethers.constants.MaxUint256)) {
+		// 	throw DripsErrors.argumentError(
+		// 		`Could not get user address: ${userId} is not a valid positive number within the range of a uint256.`
+		// 	);
+		// }
 
 		const mid64BitsMask = ethers.BigNumber.from(2).pow(64).sub(1).shl(160);
 

--- a/src/DripsHub/DripsHubClient.ts
+++ b/src/DripsHub/DripsHubClient.ts
@@ -108,6 +108,22 @@ export default class DripsHubClient {
 	}
 
 	/**
+	 * Calculates the hash of the drips receivers.
+	 * @param currentReceivers The drips receivers.
+	 * Must be sorted by the receivers' addresses, deduplicated and without 0 `amtPerSecs`.
+	 * @param provider The provider.
+	 * @returns The hash of the drips receivers.
+	 */
+	public static async hashDrips(receivers: DripsReceiverStruct[], provider: Provider): Promise<string> {
+		const hash = DripsHub__factory.connect(
+			Utils.Network.configs[(await provider.getNetwork()).chainId].DRIPS_HUB,
+			provider
+		).hashDrips(receivers);
+
+		return hash;
+	}
+
+	/**
 	 * Returns the total amount currently stored in `DripsHub` for the given token.
 	 * @param  {string} tokenAddress The ERC20 token address.
 	 *
@@ -188,7 +204,7 @@ export default class DripsHubClient {
 			);
 		}
 
-		if (!maxCycles || maxCycles < 0) {
+		if (!maxCycles || BigNumber.from(maxCycles).lt(0)) {
 			throw DripsErrors.argumentError(
 				`Could not get receivable balance: '${nameOf({ maxCycles })}' is missing.`,
 				nameOf({ maxCycles }),
@@ -392,7 +408,7 @@ export default class DripsHubClient {
 			);
 		}
 
-		if (!amount || amount < 0) {
+		if (!amount || BigNumber.from(amount).lt(0)) {
 			throw DripsErrors.argumentError(
 				`Could not get split result: '${nameOf({ amount })}' must be greater than 0.`,
 				nameOf({ amount }),

--- a/tests/AddressDriver/AddressDriverClient.integration.tests.ts
+++ b/tests/AddressDriver/AddressDriverClient.integration.tests.ts
@@ -16,7 +16,7 @@ dotenv.config();
 describe('AddressDriver integration tests', () => {
 	const THREE_MINS = 180000; // In milliseconds.
 	const WETH = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6';
-	const provider = new InfuraProvider('goerli');
+	const provider = new InfuraProvider('sepolia');
 	const account1 = process.env.ACCOUNT_1 as string;
 	const account2 = process.env.ACCOUNT_2 as string;
 	const account1AsSigner = new Wallet(process.env.ACCOUNT_1_SECRET_KEY as string);
@@ -62,7 +62,7 @@ describe('AddressDriver integration tests', () => {
 		console.log(`Updating Drips configuration...`);
 		await account2AddressDriverClient.setDrips(
 			WETH,
-			await subgraphClient.getCurrentDripsReceivers(userId2, WETH),
+			await subgraphClient.getCurrentDripsReceivers(userId2, WETH, provider),
 			[{ config, userId: userId1 }],
 			account2
 		);
@@ -93,7 +93,7 @@ describe('AddressDriver integration tests', () => {
 		console.log(`Clearing WETH configuration receivers to stop dripping...`);
 		await account2AddressDriverClient.setDrips(
 			WETH,
-			await subgraphClient.getCurrentDripsReceivers(userId2, WETH),
+			await subgraphClient.getCurrentDripsReceivers(userId2, WETH, provider),
 			[],
 			account2
 		);

--- a/tests/DripsSubgraph/DripsSubgraphClient.tests.ts
+++ b/tests/DripsSubgraph/DripsSubgraphClient.tests.ts
@@ -1858,6 +1858,7 @@ describe('DripsSubgraphClient', () => {
 					id: '502',
 					blockTimestamp: 502n,
 					assetId: Utils.Asset.getIdFromAddress(tokenAddress),
+					receiversHash: '0x6cc830f4f294a80b24635161e488f5444b0e3387c8e5d491ab8f2d68d1a6e67d',
 					dripsReceiverSeenEvents: [
 						{
 							id: '502',
@@ -1869,6 +1870,7 @@ describe('DripsSubgraphClient', () => {
 				{
 					id: '501',
 					blockTimestamp: 501n,
+					receiversHash: '0xab1290d36f461ed68109d46b0d53cd064d194773a2c6dbd0b973f51e526e80d9',
 					assetId: Utils.Asset.getIdFromAddress(tokenAddress),
 					dripsReceiverSeenEvents: [
 						{

--- a/tests/NFTDriver/NFTDriverClient.integration.tests.ts
+++ b/tests/NFTDriver/NFTDriverClient.integration.tests.ts
@@ -117,7 +117,7 @@ describe('NFTDriver integration tests', () => {
 		await account2NftDriverClient.setDrips(
 			senderSubAccount.tokenId,
 			WETH,
-			await subgraphClient.getCurrentDripsReceivers(senderSubAccount.tokenId, WETH),
+			await subgraphClient.getCurrentDripsReceivers(senderSubAccount.tokenId, WETH, provider),
 			[{ config, userId: receiverSubAccount.tokenId }],
 			account2
 		);
@@ -149,7 +149,7 @@ describe('NFTDriver integration tests', () => {
 		await account2NftDriverClient.setDrips(
 			senderSubAccount.tokenId,
 			WETH,
-			await subgraphClient.getCurrentDripsReceivers(senderSubAccount.tokenId, WETH),
+			await subgraphClient.getCurrentDripsReceivers(senderSubAccount.tokenId, WETH, provider),
 			[],
 			account2
 		);

--- a/tests/utils.tests.ts
+++ b/tests/utils.tests.ts
@@ -311,4 +311,46 @@ describe('Utils', () => {
 			});
 		});
 	});
+
+	describe('UserId', () => {
+		describe('getDriver', () => {
+			it('should return the expected result', () => {
+				// TODO: Add test case for immutable address driver user ID.
+
+				// Arrange
+				const addressDriverUserId = '846959513016227493489143736695218182523669298507';
+				const nftDriverUserId = '42583592044554662154154760653976070706375843797872425666273362826761';
+				const repoDriverUserId = '80907581203104634939800721083555800473270339779792920621438161136896';
+
+				// Act
+				const expectedNftDriverId = Utils.UserId.getDriver(nftDriverUserId);
+				const expectedRepoDriverId = Utils.UserId.getDriver(repoDriverUserId);
+				const expectedAddressDriverId = Utils.UserId.getDriver(addressDriverUserId);
+
+				// Assert
+				assert.equal(expectedNftDriverId, 'nft');
+				assert.equal(expectedRepoDriverId, 'repo');
+				assert.equal(expectedAddressDriverId, 'address');
+			});
+
+			it('should throw an error when the driver ID of the user ID is unknown', () => {
+				// TODO: Add test case for immutable address driver user ID.
+
+				// Arrange
+				let threw = false;
+
+				// Act
+				try {
+					Utils.UserId.getDriver('0x5000000000000000000000000000000000000000000000000000000000000000');
+				} catch (error: any) {
+					// Assert
+					assert.equal(error.code, DripsErrorCode.INVALID_ARGUMENT);
+					threw = true;
+				}
+
+				// Assert
+				assert.isTrue(threw, 'Expected type of exception was not thrown');
+			});
+		});
+	});
 });


### PR DESCRIPTION
- Fix wrong validation logic when calculating `AddressDriver.userId`
- Fix logic when calculating current drips list (check against receiversHash which is _always_ right)
- Add helper method to get the `driverId` from a `userId`